### PR TITLE
增加 Sites 部署支持

### DIFF
--- a/.openai/hosting.json
+++ b/.openai/hosting.json
@@ -1,0 +1,5 @@
+{
+  "project_id": "appgprj_6a89ddf8c91c8191be70429a0bbcb88d",
+  "d1": null,
+  "r2": null
+}

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "build:offline": "npm run build && node scripts/build-offline.mjs",
+    "build:sites": "npm run build:offline && node scripts/build-sites.mjs",
     "typecheck": "tsc -b --pretty false",
     "test:unit": "vitest run",
     "test:real": "node --import tsx scripts/validate-real-file.ts",

--- a/scripts/build-sites.mjs
+++ b/scripts/build-sites.mjs
@@ -1,0 +1,44 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const projectRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const offlineHtmlPath = resolve(projectRoot, "release/Microplate-Assay-Studio-Offline.html");
+const workerDirectory = resolve(projectRoot, "dist/server");
+const workerPath = resolve(workerDirectory, "index.js");
+
+const html = await readFile(offlineHtmlPath, "utf8");
+if (!html.includes("Microplate Assay Studio") || !html.includes("酶标数据入口")) {
+  throw new Error("The offline build is incomplete and cannot be prepared for Sites.");
+}
+
+const serializedHtml = JSON.stringify(html)
+  .replaceAll("\u2028", "\\u2028")
+  .replaceAll("\u2029", "\\u2029");
+
+const worker = `const html = ${serializedHtml};
+
+export default {
+  async fetch(request) {
+    if (request.method !== "GET" && request.method !== "HEAD") {
+      return new Response("Method Not Allowed", {
+        status: 405,
+        headers: { Allow: "GET, HEAD" },
+      });
+    }
+
+    return new Response(request.method === "HEAD" ? null : html, {
+      headers: {
+        "Content-Type": "text/html; charset=utf-8",
+        "Cache-Control": "no-cache",
+        "Referrer-Policy": "no-referrer",
+        "X-Content-Type-Options": "nosniff",
+      },
+    });
+  },
+};
+`;
+
+await mkdir(workerDirectory, { recursive: true });
+await writeFile(workerPath, worker, "utf8");
+console.log(`Sites worker written to ${workerPath}`);


### PR DESCRIPTION
Closes #9

## 修改
- 绑定唯一的 Microplate Assay Studio Sites 项目。
- 增加可复现的 Sites 构建脚本，将已验证的离线应用封装为生产 Worker。
- 保持浏览器本地数据处理方式和现有 v0.4 功能不变。

## 验证
- 8 个测试文件、26 项测试通过。
- 生产构建和 Sites 构建通过。
- Worker 响应 200，包含 v0.4 酶标数据入口。
- Sites v1 已成功部署，权限保持仅所有者可访问。