### PR TITLE
移除 CCK-8 汇总导出的重复值列

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Microplate Assay Studio
 
-面向酶标仪/多功能微孔板读数仪的一体化分析工作台。当前版本为 v0.5.2，使用真实 Thermo Scientific Varioskan LUX / SkanIt XML、XLSX 和旧版 VICTOR XLS 数据开发。
+面向酶标仪/多功能微孔板读数仪的一体化分析工作台。当前版本为 v0.5.3，使用真实 Thermo Scientific Varioskan LUX / SkanIt XML、XLSX 和旧版 VICTOR XLS 数据开发。
 
 ## 工具定位
 
@@ -21,7 +21,7 @@
 6. 支持 CCK-8/MTT/Resazurin/alamarBlue、BSA 蛋白定量与光谱、ATP 发光定量和 Dual-Luciferase demo 流程。
 7. 对 CCK-8 类组间实验，区分技术复孔与生物学重复，完成空白扣除、QC、对照归一化及显著性分析；同一块板允许存在多个独立的生物学重复，但技术复孔仍先在各自生物学重复内汇总。
 8. 对 ATP、BSA、alamarBlue 标准曲线和 Dual-Luciferase，逐步展示 SkanIt 原始测量与仪器计算结果，不擅自替换仪器算法。
-9. 导出包含当前孔注释、模块确认、选择决策、来源适配器、测量步骤和全部数据点的 tidy long-table CSV；CCK-8 流程另可导出孔级、技术复孔和生物学汇总结果。汇总 CSV 的主值固定为 blank-corrected signal；相对 Control 的百分比使用独立派生列，不覆盖后续跨时间分析所需的基础值。
+9. 导出包含当前孔注释、模块确认、选择决策、来源适配器、测量步骤和全部数据点的 tidy long-table CSV；CCK-8 流程另可导出孔级、技术复孔和生物学汇总结果。汇总 CSV 只保留明确命名的 `blank_corrected_*` 基础列和 `relative_to_control_*` 派生列，不设置重复的通用 `value / sd / sem` 别名。
 10. 可保存并重新打开浏览器本地的可复现项目文件，恢复原始读值、当前注释、实验基本信息、模块识别/确认和分析配置。
 11. 无仪器原始文件时，可直接粘贴 Excel 中的固定孔板矩阵，或下载并填写 6/12/24/48/96/384 孔读数模板后导入。
 12. 同一次粘贴或模板导入可识别多块板；每块板保留独立名称、注释和分析状态，不会自动合并为生物学重复。

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "microplate-assay-studio",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "microplate-assay-studio",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "dependencies": {
         "react": "19.2.6",
         "react-dom": "19.2.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "microplate-assay-studio",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "private": true,
   "type": "module",
   "engines": {

--- a/scripts/visual-smoke.mjs
+++ b/scripts/visual-smoke.mjs
@@ -127,7 +127,7 @@ try {
   await page.getByRole("button", { name: /分析与导出/ }).click();
   const manualAnalysisText = await page.locator("body").innerText();
   if (!manualAnalysisText.includes("ROLE_UNASSIGNED")) throw new Error("Manual-paste analysis did not preserve the unassigned-well QC gate.");
-  if (!manualAnalysisText.includes("主值始终为未归一化的 blank-corrected signal")) throw new Error("Analysis UI did not explain the unnormalized export basis.");
+  if (!manualAnalysisText.includes("只保留语义明确的 blank_corrected_* 基础列")) throw new Error("Analysis UI did not explain the explicit export schema.");
   await page.locator(".workspace-nav").getByRole("button", { name: /数据导入/ }).click();
   const projectDownloadEvent = page.waitForEvent("download");
   await page.getByRole("button", { name: "保存可复现项目" }).click();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -781,7 +781,7 @@ export default function App() {
 
           <section className="panel table-panel summary-panel">
             <div className="panel-head summary-panel-head">
-              <div><h3>生物学汇总表</h3><p>{selectedSummaryKeys.size ? `当前展示 ${displayedBiologicalSummaries.length} 行；显著性按当前点选范围重新计算。` : "点击行后，下方图表、显著性和导出内容只显示所选行。"} 汇总 CSV 的主值始终为未归一化的 blank-corrected signal；Rel. % 仅作为相对 Control 的派生列。</p></div>
+              <div><h3>生物学汇总表</h3><p>{selectedSummaryKeys.size ? `当前展示 ${displayedBiologicalSummaries.length} 行；显著性按当前点选范围重新计算。` : "点击行后，下方图表、显著性和导出内容只显示所选行。"} 汇总 CSV 只保留语义明确的 blank_corrected_* 基础列；relative_to_control_* 仅表示相对 Control 的派生结果。</p></div>
               <div className="summary-head-actions">
                 {selectedSummaryKeys.size ? <button type="button" className="secondary-button mini" onClick={() => setWorkspace((current) => current ? transitionPlateWorkspace(current, { type: "clear-summary-selection" }) : current)}>显示全部</button> : null}
                 <button type="button" className="secondary-button mini" disabled={!displayedAnnotatedWells.length} onClick={() => exportFiles("wells")}>孔级 CSV</button>

--- a/src/core/artifacts.ts
+++ b/src/core/artifacts.ts
@@ -74,7 +74,7 @@ function technicalSummaryCsv(result: CellViabilityAnalysisResult, plate: ParsedP
 function biologicalSummaryCsv(result: CellViabilityAnalysisResult, plate: ParsedPlate, analysisConfig?: AnalysisConfig): string {
   const comparisonByGroup = new Map(result.significanceComparisons.map((comparison) => [[comparison.group, comparison.treatment, comparison.concentration, comparison.timepoint].join("¦"), comparison]));
   const headers = [
-    "category", "value", "sd", "sem", "signal_basis", "group", "treatment", "concentration", "timepoint", "n_biological",
+    "category", "group", "treatment", "concentration", "timepoint", "n_biological", "signal_basis",
     "blank_corrected_mean", "blank_corrected_sd", "blank_corrected_sem",
     "relative_to_control_percent", "relative_to_control_sd_percent", "relative_to_control_sem_percent", "normalization_reference",
     "p_value_vs_control", "fdr_vs_control", "significance", "plate_name", "import_source",
@@ -83,9 +83,9 @@ function biologicalSummaryCsv(result: CellViabilityAnalysisResult, plate: Parsed
     const comparison = comparisonByGroup.get([row.group, row.treatment, row.concentration, row.timepoint].join("¦"));
     return {
       category: [row.group, row.concentration, row.timepoint].filter(Boolean).join(" · "),
-      value: row.correctedMean, sd: row.correctedSd, sem: row.correctedSem, signal_basis: "blank-corrected",
       group: row.group, treatment: row.treatment,
       concentration: row.concentration, timepoint: row.timepoint, n_biological: row.nBiological,
+      signal_basis: "blank-corrected",
       blank_corrected_mean: row.correctedMean, blank_corrected_sd: row.correctedSd, blank_corrected_sem: row.correctedSem,
       relative_to_control_percent: row.relativeActivityPercent, relative_to_control_sd_percent: row.relativeSdPercent,
       relative_to_control_sem_percent: row.relativeSemPercent,

--- a/tests/cck8.test.ts
+++ b/tests/cck8.test.ts
@@ -93,13 +93,15 @@ describe("CCK-8 analysis", () => {
     const value = (column: string) => drugCsvRow?.[headers.indexOf(column)];
 
     expect(headers).toEqual(expect.arrayContaining([
-      "value", "sd", "sem", "signal_basis", "blank_corrected_mean", "blank_corrected_sd", "blank_corrected_sem",
+      "signal_basis", "blank_corrected_mean", "blank_corrected_sd", "blank_corrected_sem",
       "relative_to_control_percent", "relative_to_control_sd_percent", "relative_to_control_sem_percent", "normalization_reference",
     ]));
-    expect(Number(value("value"))).toBeCloseTo(0.1, 12);
-    expect(Number(value("sd"))).toBeCloseTo(0.01, 12);
+    expect(headers).not.toContain("value");
+    expect(headers).not.toContain("sd");
+    expect(headers).not.toContain("sem");
     expect(value("signal_basis")).toBe("blank-corrected");
     expect(Number(value("blank_corrected_mean"))).toBeCloseTo(0.1, 12);
+    expect(Number(value("blank_corrected_sd"))).toBeCloseTo(0.01, 12);
     expect(Number(value("relative_to_control_percent"))).toBeCloseTo(50, 12);
     expect(Number(value("relative_to_control_sd_percent"))).toBeCloseTo(5, 12);
     expect(value("normalization_reference")).toBe("Vehicle");


### PR DESCRIPTION
## 改动
- 删除与 `blank_corrected_*` 完全重复的通用 `value / sd / sem` 列
- 基础信号只保留 `blank_corrected_mean / sd / sem`
- 相对 Control 的派生结果继续使用 `relative_to_control_*`
- 更新 UI、README 与测试，明确无重复别名的导出 schema

## 验证
- `npm test`：36 tests passed，生产构建通过
- `npm run test:browser`：通过，无控制台错误
- 测试明确断言汇总 CSV 不含 `value / sd / sem`
- `git diff --check`：通过

Closes #19