### PR TITLE
Refine the UI into a compact scientific workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Microplate Assay Studio
 
-面向酶标仪/多功能微孔板读数仪的一体化分析工作台。当前版本为 v0.5.3，使用真实 Thermo Scientific Varioskan LUX / SkanIt XML、XLSX 和旧版 VICTOR XLS 数据开发。
+面向酶标仪/多功能微孔板读数仪的一体化分析工作台。当前版本为 v0.5.4，使用真实 Thermo Scientific Varioskan LUX / SkanIt XML、XLSX 和旧版 VICTOR XLS 数据开发。
 
 ## 工具定位
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "microplate-assay-studio",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "microplate-assay-studio",
-      "version": "0.5.3",
+      "version": "0.5.4",
       "dependencies": {
         "react": "19.2.6",
         "react-dom": "19.2.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "microplate-assay-studio",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "private": true,
   "type": "module",
   "engines": {

--- a/scripts/visual-smoke.mjs
+++ b/scripts/visual-smoke.mjs
@@ -29,6 +29,13 @@ try {
   if (!(await page.locator("body").innerText()).includes("Firefly 与 Renilla 步骤映射")) throw new Error("Luciferase-specific workflow guidance is missing.");
   await page.getByRole("button", { name: /细胞活性 \/ 细胞增殖/ }).click();
   await page.screenshot({ path: resolve(screenshotDir, "microplate-studio-start.png"), fullPage: true });
+  const topbarBounds = await page.locator(".topbar").boundingBox();
+  const assayStripBounds = await page.locator(".assay-strip").boundingBox();
+  const sectionCopySize = Number.parseFloat(await page.locator(".section-heading p").first().evaluate((element) => getComputedStyle(element).fontSize));
+  if (!topbarBounds || topbarBounds.height > 60) throw new Error(`Top bar is no longer compact: ${topbarBounds?.height ?? "missing"}px.`);
+  if (!assayStripBounds || assayStripBounds.height > 230) throw new Error(`Assay selector is no longer compact: ${assayStripBounds?.height ?? "missing"}px.`);
+  if (sectionCopySize < 11) throw new Error(`Workspace copy is too small: ${sectionCopySize}px.`);
+  if (await page.locator(".eyebrow").count()) throw new Error("Redundant section eyebrow labels returned to the workspace.");
 
   if (process.env.CCK8_XLS) {
     await page.getByRole("button", { name: /蛋白定量/ }).click();
@@ -118,6 +125,8 @@ try {
   const compactAnnotation = await page.locator(".annotation-panel").boundingBox();
   if (!compactPlate || !compactAnnotation || compactAnnotation.y <= compactPlate.y) throw new Error("Narrow layout did not move the annotation panel below the plate.");
   await page.screenshot({ path: resolve(screenshotDir, "microplate-studio-layout-narrow.png"), fullPage: true });
+  const narrowOverflow = await page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth);
+  if (narrowOverflow > 1) throw new Error(`Narrow workspace has ${narrowOverflow}px of page-level horizontal overflow.`);
   await page.getByRole("button", { name: "收起批量注释" }).click();
   const compactCollapsedAnnotation = await page.locator(".annotation-panel").boundingBox();
   if (!compactCollapsedAnnotation || compactCollapsedAnnotation.height > 100) throw new Error("Narrow collapsed annotation panel did not become a compact horizontal bar.");

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -70,7 +70,7 @@ const emptyBatchDraft: BatchDraft = {
 };
 
 function format(value: number | null, digits = 3): string {
-  return value === null || !Number.isFinite(value) ? "—" : value.toFixed(digits);
+  return value === null || !Number.isFinite(value) ? "未记录" : value.toFixed(digits);
 }
 
 function detectionModeLabel(mode: DetectionMode): string {
@@ -84,8 +84,8 @@ function methodEvidenceLabel(plate: ParsedPlate): string {
 function measurementChannel(plate: ParsedPlate): string {
   const metadata = plate.metadata;
   if (metadata.detectionMode === "fluorescence") {
-    const excitation = metadata.excitationWavelengthNm ? `Ex ${metadata.excitationWavelengthNm} nm` : "Ex —";
-    const emission = metadata.emissionWavelengthNm ? `Em ${metadata.emissionWavelengthNm} nm` : "Em —";
+    const excitation = metadata.excitationWavelengthNm ? `Ex ${metadata.excitationWavelengthNm} nm` : "Ex 未记录";
+    const emission = metadata.emissionWavelengthNm ? `Em ${metadata.emissionWavelengthNm} nm` : "Em 未记录";
     return `${excitation} / ${emission}`;
   }
   if (metadata.wavelengthNm) {
@@ -93,11 +93,11 @@ function measurementChannel(plate: ParsedPlate): string {
       ? `${metadata.wavelengthNm} nm / ref ${metadata.referenceWavelengthNm} nm`
       : `${metadata.wavelengthNm} nm`;
   }
-  return metadata.measurementName || "—";
+  return metadata.measurementName || "未记录";
 }
 
 function instrumentDisplay(plate: ParsedPlate): string {
-  return [plate.metadata.instrumentManufacturer, plate.metadata.instrumentModel].filter(Boolean).join(" · ") || "—";
+  return [plate.metadata.instrumentManufacturer, plate.metadata.instrumentModel].filter(Boolean).join(" · ") || "未记录";
 }
 
 function readSettingDisplay(plate: ParsedPlate): string {
@@ -109,7 +109,7 @@ function readSettingDisplay(plate: ParsedPlate): string {
       ? `${metadata.temperatureStartC}→${metadata.temperatureEndC} °C`
       : "",
   ].filter(Boolean);
-  return items.join(" · ") || "—";
+  return items.join(" · ") || "未记录";
 }
 
 function formatRawSignal(plate: ParsedPlate, value: number): string {
@@ -124,9 +124,9 @@ function rawSignalLabel(plate: ParsedPlate): string {
 
 const summaryTableColumns: Array<{ key: string; header: string; render: (row: BiologicalSummary) => string | number }> = [
   { key: "group", header: "Group", render: (row) => row.group },
-  { key: "treatment", header: "Treatment", render: (row) => row.treatment || "—" },
-  { key: "concentration", header: "Conc.", render: (row) => row.concentration || "—" },
-  { key: "timepoint", header: "Time", render: (row) => row.timepoint || "—" },
+  { key: "treatment", header: "Treatment", render: (row) => row.treatment || "未记录" },
+  { key: "concentration", header: "Conc.", render: (row) => row.concentration || "未记录" },
+  { key: "timepoint", header: "Time", render: (row) => row.timepoint || "未记录" },
   { key: "nBiological", header: "n bio", render: (row) => row.nBiological },
   { key: "correctedMean", header: "Mean", render: (row) => format(row.correctedMean) },
   { key: "correctedSd", header: "SD", render: (row) => format(row.correctedSd) },
@@ -580,8 +580,8 @@ export default function App() {
       {error ? <div className="notice warning" role="alert">{error}<button type="button" onClick={() => setError("")}>×</button></div> : null}
 
       {view === "import" ? <section className="workspace import-workspace">
-        <div className="section-heading">
-          <div><p className="eyebrow">01 · PLATE READINGS</p><h2>导入孔板读数</h2><p>当前模块：{selectedModule.name} · {selectedModule.measurementTarget}。可以导入仪器结果，也可以粘贴 Excel 矩阵或填写标准读数模板；全部数据只在浏览器本地处理。</p></div>
+        <div className="section-heading split">
+          <div><h2>导入孔板读数</h2><p>当前模块：{selectedModule.name} · {selectedModule.measurementTarget}。可以导入仪器结果，也可以粘贴 Excel 矩阵或填写标准读数模板；全部数据只在浏览器本地处理。</p></div>
           <div className="import-heading-actions">{plate ? <><span className="adapter-badge">{plate.metadata.adapterId}</span><button type="button" className="secondary-button mini" onClick={downloadProjectFile}>保存可复现项目</button></> : null}<input ref={projectInput} hidden type="file" accept=".json" onChange={(event) => { const file = event.target.files?.[0]; if (file) void previewProjectFile(file); event.target.value = ""; }} /><button type="button" className="secondary-button mini" onClick={() => projectInput.current?.click()}>重新打开项目文件</button></div>
         </div>
         <AssayWorkflowPanel module={selectedModule} plate={plate && activeModuleId === selectedModuleId ? plate : null} />
@@ -657,7 +657,7 @@ export default function App() {
             <Metric label="检测模式" value={detectionModeLabel(plate.metadata.detectionMode)} detail={`${plate.metadata.measurementName || "未命名通道"} · ${plate.metadata.signalUnit || "无单位"}`} />
             <Metric label="读数通道" value={measurementChannel(plate)} detail={plate.metadata.detectionMode === "fluorescence" ? "激发 / 发射" : "主波长 / 参比波长"} />
             <Metric label="仪器" value={instrumentDisplay(plate)} detail={plate.metadata.instrumentSerialNumber ? `S/N ${plate.metadata.instrumentSerialNumber}` : "序列号未记录"} />
-            <Metric label="运行" value={plate.metadata.runTimestamp || "—"} detail={plate.metadata.assayId ? `Assay ID ${plate.metadata.assayId}` : "Assay ID 未记录"} />
+            <Metric label="运行" value={plate.metadata.runTimestamp || "未记录"} detail={plate.metadata.assayId ? `Assay ID ${plate.metadata.assayId}` : "Assay ID 未记录"} />
             <Metric label="板型" value={`${plate.rows} × ${plate.columns} · ${plate.rows * plate.columns} 孔`} detail={`${plate.wells.length} 个已测孔 · ${plate.metadata.plateType || "板型未命名"}`} />
             <Metric label="读板设置" value={readSettingDisplay(plate)} detail={plate.metadata.readDirection ? `原文：${plate.metadata.readDirection}` : "文件未记录读板方向"} />
             <Metric label="来源" value={plate.metadata.sourceFileName} detail={plate.metadata.protocolName || plate.metadata.sourceExperiment || "协议名未记录"} />
@@ -669,7 +669,7 @@ export default function App() {
 
       {view === "layout" && plate ? <section className="workspace">
         <div className="section-heading split">
-          <div><p className="eyebrow">02 · PLATE IDENTITY</p><h2>板图与实验注释</h2><p>{activeModule.annotationGuidance} 仪器标签不是实验分组，系统不会根据原始读数高低猜测角色或重复。</p></div>
+          <div><h2>板图与实验注释</h2><p>{activeModule.annotationGuidance} 仪器标签不是实验分组，系统不会根据原始读数高低猜测角色或重复。</p></div>
           <div className="inline-actions">
             <input ref={layoutInput} hidden type="file" accept=".csv,.tsv,.txt" onChange={(event) => { const file = event.target.files?.[0]; if (file) void previewLayoutFile(file); event.target.value = ""; }} />
             <select className="template-select" value={layoutTemplateId} onChange={(event) => setLayoutTemplateId(event.target.value)} aria-label="板图模板类型">
@@ -753,7 +753,7 @@ export default function App() {
 
       {view === "analysis" && plate && useGenericWorkflow && plate.assayData ? <section className="workspace analysis-workspace">
         <div className="section-heading split compact-heading">
-          <div><p className="eyebrow">02 · RESULT EXPLORER</p><h2>分析与导出</h2><p>按 SkanIt 测量和计算步骤浏览终点、动力学、光谱、标准曲线与多通道归一化结果。</p></div>
+          <div><h2>分析与导出</h2><p>按 SkanIt 测量和计算步骤浏览终点、动力学、光谱、标准曲线与多通道归一化结果。</p></div>
           <span className="readiness ready">{assayStatusLabel(activeModule.status)}</span>
         </div>
         <AssayWorkflowPanel module={activeModule} plate={plate} />
@@ -762,7 +762,7 @@ export default function App() {
 
       {view === "analysis" && plate && !useGenericWorkflow ? <section className="workspace analysis-workspace">
         <div className="section-heading split compact-heading">
-          <div><p className="eyebrow">03 · QC & ANALYSIS</p><h2>分析与导出</h2><p>先合并技术复孔，再以生物学重复为统计单位；点选汇总表行后，下方图表、显著性和导出 CSV 都只保留当前展示范围。</p></div>
+          <div><h2>分析与导出</h2><p>先合并技术复孔，再以生物学重复为统计单位；点选汇总表行后，下方图表、显著性和导出 CSV 都只保留当前展示范围。</p></div>
           <div className="analysis-heading-actions"><span className={`readiness ${analysis.ready ? "ready" : "review"}`}>{analysis.ready ? "Ready for export" : "Review required"}</span><button type="button" className="secondary-button mini" onClick={downloadProjectFile}>保存可复现项目</button></div>
         </div>
         <div className="analysis-layout-compact">
@@ -801,7 +801,7 @@ export default function App() {
 
           <aside className="analysis-result-side">
             <div className="panel chart-panel compact-chart-panel"><div className="panel-head compact-panel-head"><div><h3>图表预览</h3><p>辅助查看趋势；正式结果以左侧汇总表和统计表为准。</p></div></div><SummaryChart rows={displayedBiologicalSummaries} normalized={Boolean(config.controlGroup)} compact yAxisLabel={`Blank-corrected signal${plate.metadata.signalUnit ? ` (${plate.metadata.signalUnit})` : ""}`} /></div>
-            <div className="panel table-panel significance-panel"><div className="panel-head compact-panel-head"><div><h3>显著性</h3><p>{selectedSummaryKeys.size ? "按当前点选行重新计算；自动加入同时间点 control 与 blank。" : "全表范围计算；单位是生物学重复，不把技术复孔当作独立 n。"}</p></div></div><div className="method-note"><strong>计算方法</strong><p>先扣除 blank，再合并同一 biological replicate 内的技术复孔。若处理组和对照组共享相同 B 编号，使用配对 t-test；无法配对时使用 Welch t-test。P 值用当前范围内的 Benjamini-Hochberg FDR 校正，星号按 FDR 标注。</p><p>推荐原则：单时间点两组比较用配对/独立 t-test；多处理组优先用 ANOVA + Dunnett 或 FDR；连续多时间点应考虑 two-way ANOVA 或混合效应模型。</p></div><div className="table-scroll compact"><table><thead><tr><th>Contrast</th><th>Method</th><th>n</th><th>Diff</th><th>P</th><th>FDR</th><th>Sig.</th></tr></thead><tbody>{displayedSignificanceComparisons.length ? displayedSignificanceComparisons.map((row) => <tr key={row.key}><td>{row.contrast}</td><td>{significanceMethodLabel(row.note)}</td><td>{row.nGroup}/{row.nControl}</td><td>{Number.isFinite(row.meanDifference) ? format(row.meanDifference) : "—"}</td><td>{row.pValue === null ? "n/a" : row.pValue.toPrecision(3)}</td><td>{row.adjustedPValue === null ? "n/a" : row.adjustedPValue.toPrecision(3)}</td><td>{row.label}</td></tr>) : <tr><td colSpan={7} className="empty-cell">{config.controlGroup ? "当前展示范围没有可比较的非对照组。" : "选择对照组后计算显著性。"}</td></tr>}</tbody></table></div></div>
+            <div className="panel table-panel significance-panel"><div className="panel-head compact-panel-head"><div><h3>显著性</h3><p>{selectedSummaryKeys.size ? "按当前点选行重新计算；自动加入同时间点 control 与 blank。" : "全表范围计算；单位是生物学重复，不把技术复孔当作独立 n。"}</p></div></div><div className="method-note"><strong>计算方法</strong><p>先扣除 blank，再合并同一 biological replicate 内的技术复孔。若处理组和对照组共享相同 B 编号，使用配对 t-test；无法配对时使用 Welch t-test。P 值用当前范围内的 Benjamini-Hochberg FDR 校正，星号按 FDR 标注。</p><p>推荐原则：单时间点两组比较用配对/独立 t-test；多处理组优先用 ANOVA + Dunnett 或 FDR；连续多时间点应考虑 two-way ANOVA 或混合效应模型。</p></div><div className="table-scroll compact"><table><thead><tr><th>Contrast</th><th>Method</th><th>n</th><th>Diff</th><th>P</th><th>FDR</th><th>Sig.</th></tr></thead><tbody>{displayedSignificanceComparisons.length ? displayedSignificanceComparisons.map((row) => <tr key={row.key}><td>{row.contrast}</td><td>{significanceMethodLabel(row.note)}</td><td>{row.nGroup}/{row.nControl}</td><td>{Number.isFinite(row.meanDifference) ? format(row.meanDifference) : "未计算"}</td><td>{row.pValue === null ? "n/a" : row.pValue.toPrecision(3)}</td><td>{row.adjustedPValue === null ? "n/a" : row.adjustedPValue.toPrecision(3)}</td><td>{row.label}</td></tr>) : <tr><td colSpan={7} className="empty-cell">{config.controlGroup ? "当前展示范围没有可比较的非对照组。" : "选择对照组后计算显著性。"}</td></tr>}</tbody></table></div></div>
           </aside>
         </div>
       </section> : null}

--- a/src/components/AssayDataExplorer.tsx
+++ b/src/components/AssayDataExplorer.tsx
@@ -4,7 +4,7 @@ import type { AssayDataset, MeasurementPoint, MeasurementSeries, StandardCurve }
 const palette = ["#1d4c50", "#d88962", "#5f7565", "#8b6f92", "#b18b52", "#54758a", "#a55f59", "#64714d"];
 
 function number(value: number | null, digits = 4): string {
-  if (value === null || !Number.isFinite(value)) return "—";
+  if (value === null || !Number.isFinite(value)) return "未记录";
   if (Math.abs(value) >= 10000 || (Math.abs(value) > 0 && Math.abs(value) < 0.001)) return value.toExponential(3);
   return value.toLocaleString(undefined, { maximumFractionDigits: digits });
 }
@@ -89,7 +89,7 @@ export function AssayDataExplorer({ dataset, onExport, onExportProject }: { data
     </section>
     <div className="assay-result-grid">
       <section className="panel assay-preview-panel"><div className="panel-head compact-panel-head"><div><h3>{selected.name}</h3><p>{selected.source === "measured" ? "仪器测量" : "仪器计算"} · {selected.detectionMode} · {selected.signalUnit}</p></div></div><LinePreview series={selected} /></section>
-      <section className="panel assay-data-panel"><div className="panel-head compact-panel-head"><div><h3>结果明细</h3><p>当前步骤最多预览 300 行；导出文件包含全部结果。</p></div></div><div className="table-scroll"><table><thead><tr><th>Well</th><th>Sample</th><th>Group</th><th>Conc.</th><th>Time s</th><th>λ nm</th><th>Value</th><th>Type</th></tr></thead><tbody>{displayedPoints.map((point, index) => <tr key={`${point.well}-${index}`}><td>{point.well}</td><td>{point.sampleName || "—"}</td><td>{point.group || "—"}</td><td>{point.concentration === null ? "—" : `${number(point.concentration)} ${point.concentrationUnit}`}</td><td>{number(point.timeSeconds, 2)}</td><td>{number(point.wavelengthNm ?? point.emissionWavelengthNm ?? point.excitationWavelengthNm, 1)}</td><td>{number(point.value)}</td><td>{point.valueType}</td></tr>)}</tbody></table></div></section>
+      <section className="panel assay-data-panel"><div className="panel-head compact-panel-head"><div><h3>结果明细</h3><p>当前步骤最多预览 300 行；导出文件包含全部结果。</p></div></div><div className="table-scroll"><table><thead><tr><th>Well</th><th>Sample</th><th>Group</th><th>Conc.</th><th>Time s</th><th>λ nm</th><th>Value</th><th>Type</th></tr></thead><tbody>{displayedPoints.map((point, index) => <tr key={`${point.well}-${index}`}><td>{point.well}</td><td>{point.sampleName || "未记录"}</td><td>{point.group || "未记录"}</td><td>{point.concentration === null ? "未记录" : `${number(point.concentration)} ${point.concentrationUnit}`}</td><td>{number(point.timeSeconds, 2)}</td><td>{number(point.wavelengthNm ?? point.emissionWavelengthNm ?? point.excitationWavelengthNm, 1)}</td><td>{number(point.value)}</td><td>{point.valueType}</td></tr>)}</tbody></table></div></section>
     </div>
     {dataset.standardCurves.map((curve) => <StandardCurvePanel key={curve.id} curve={curve} />)}
     <div className="method-note assay-provenance-note"><strong>结果解释边界</strong><p>标准曲线、浓度、峰值、背景扣除和通道比值均优先展示 SkanIt 已导出的结果与公式；本工具不在缺少原始协议参数时擅自替换仪器算法。若要进行组间显著性检验，需补充真实独立的生物学重复；同一板可以包含多个独立 Bio，但每个 Bio 内的技术复孔不能作为独立 n。</p>{onExportProject ? <small>“可复现项目”用于以后恢复原始读数、注释、模块确认和参数；常规结果交换请优先使用 CSV。</small> : null}</div>

--- a/src/components/AssayWorkflowPanel.tsx
+++ b/src/components/AssayWorkflowPanel.tsx
@@ -15,7 +15,7 @@ export function AssayWorkflowPanel({ module, plate }: { module: AssayModuleDefin
     <div className="assay-workflow-columns">
       <div><strong>导入后需要确认</strong><ul>{module.requiredInformation.map((item) => <li key={item}>{item}</li>)}</ul></div>
       <div><strong>当前可以完成</strong>{module.availableAnalyses.length ? <ul>{module.availableAnalyses.map((item) => <li key={item}>{item}</li>)}</ul> : <p>尚未开放分析。</p>}</div>
-      <div><strong>尚未由本系统计算</strong>{module.deferredAnalyses.length ? <ul>{module.deferredAnalyses.map((item) => <li key={item}>{item}</li>)}</ul> : <p>—</p>}</div>
+      <div><strong>尚未由本系统计算</strong>{module.deferredAnalyses.length ? <ul>{module.deferredAnalyses.map((item) => <li key={item}>{item}</li>)}</ul> : <p>无</p>}</div>
     </div>
     {facts.length ? <div className="assay-workflow-facts">{facts.map((fact) => <div key={fact.label}><span>{fact.label}</span><strong>{fact.value}</strong><small className={fact.evidence}>{fact.evidence === "instrument" ? "仪器提供" : fact.evidence === "user" ? "用户填写" : "需要补充"}</small></div>)}</div> : null}
     <p className="annotation-guidance"><strong>注释建议：</strong>{module.annotationGuidance}</p>

--- a/src/components/PlateMap.tsx
+++ b/src/components/PlateMap.tsx
@@ -282,7 +282,7 @@ export function PlateMap({
                 }}
               >
                 <strong>{Math.abs(well.rawValue) >= 100 ? well.rawValue.toFixed(0) : well.rawValue.toFixed(3)}</strong>
-                <small>{well.group || well.instrumentLabel || "—"}</small>
+                <small>{well.group || well.instrumentLabel || "未指定"}</small>
               </button>;
             }),
           ])}

--- a/src/styles.css
+++ b/src/styles.css
@@ -4,41 +4,41 @@
   /* LabNest-aligned design tokens. Tune UI density and typography here first. */
   --ln-font-sans: Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC", "Microsoft YaHei", sans-serif;
 
-  --ln-color-night: #183f42;
-  --ln-color-primary: #1d4c50;
-  --ln-color-primary-strong: #163c40;
-  --ln-color-primary-soft: #e8f0ee;
-  --ln-color-ink: #262824;
-  --ln-color-text: #514c44;
-  --ln-color-muted: #81796f;
-  --ln-color-line: #e1d8cf;
-  --ln-color-line-strong: #c9b9aa;
+  --ln-color-night: #173b3e;
+  --ln-color-primary: #205156;
+  --ln-color-primary-strong: #173f43;
+  --ln-color-primary-soft: #e7efed;
+  --ln-color-ink: #202624;
+  --ln-color-text: #4c5551;
+  --ln-color-muted: #737c77;
+  --ln-color-line: #dce2dd;
+  --ln-color-line-strong: #c4cec7;
   --ln-color-surface: #ffffff;
-  --ln-color-surface-warm: #fffdf9;
-  --ln-color-panel-head: #fffaf3;
-  --ln-color-canvas: #f6f1ea;
+  --ln-color-surface-warm: #fafbf9;
+  --ln-color-panel-head: #f5f7f4;
+  --ln-color-canvas: #f1f4f1;
   --ln-color-success: #3f6b5b;
   --ln-color-success-soft: #edf4ef;
   --ln-color-warning: #9a6f43;
   --ln-color-warning-soft: #fff3e5;
   --ln-color-danger: #af5f54;
   --ln-color-danger-soft: #fff0ec;
-  --ln-color-accent: #dda278;
+  --ln-color-accent: #b98261;
   --ln-color-tea-brown: #5c503f;
   --ln-color-reed-gray: #bdaead;
   --ln-color-reed-gray-soft: #f2ece9;
 
-  --ln-font-size-2xs: 7px;
-  --ln-font-size-xs: 8px;
-  --ln-font-size-sm: 9px;
-  --ln-font-size-md: 10px;
-  --ln-font-size-lg: 11px;
-  --ln-font-size-xl: 12px;
-  --ln-font-size-title-sm: 13px;
-  --ln-font-size-title-md: 14px;
-  --ln-font-size-title-lg: 24px;
-  --ln-font-size-title-xl: 26px;
-  --ln-font-size-hero: clamp(21px, 2.5vw, 32px);
+  --ln-font-size-2xs: 9px;
+  --ln-font-size-xs: 10px;
+  --ln-font-size-sm: 11px;
+  --ln-font-size-md: 12px;
+  --ln-font-size-lg: 12px;
+  --ln-font-size-xl: 13px;
+  --ln-font-size-title-sm: 14px;
+  --ln-font-size-title-md: 15px;
+  --ln-font-size-title-lg: 20px;
+  --ln-font-size-title-xl: 22px;
+  --ln-font-size-hero: clamp(20px, 2vw, 26px);
 
   --ln-line-height-tight: 1.28;
   --ln-line-height-normal: 1.45;
@@ -55,37 +55,37 @@
   --ln-space-8: 18px;
   --ln-space-9: 20px;
   --ln-space-10: 24px;
-  --ln-space-12: 30px;
-  --ln-space-14: 36px;
+  --ln-space-12: 24px;
+  --ln-space-14: 30px;
 
   --ln-radius-xs: 5px;
   --ln-radius-sm: 7px;
   --ln-radius-md: 8px;
   --ln-radius-lg: 10px;
   --ln-radius-xl: 12px;
-  --ln-radius-2xl: 18px;
+  --ln-radius-2xl: 12px;
   --ln-radius-pill: 999px;
 
-  --ln-control-height: 40px;
-  --ln-control-height-sm: 34px;
-  --ln-control-height-xs: 30px;
-  --ln-control-padding-y: 9px;
+  --ln-control-height: 36px;
+  --ln-control-height-sm: 32px;
+  --ln-control-height-xs: 28px;
+  --ln-control-padding-y: 7px;
   --ln-control-padding-x: 10px;
-  --ln-button-height: 39px;
-  --ln-button-padding-y: 9px;
+  --ln-button-height: 36px;
+  --ln-button-padding-y: 7px;
   --ln-button-padding-x: 13px;
 
   --ln-table-font-size: var(--ln-font-size-lg);
   --ln-table-header-font-size: var(--ln-font-size-lg);
-  --ln-table-cell-padding-y: 7px;
+  --ln-table-cell-padding-y: 6px;
   --ln-table-cell-padding-x: 8px;
   --ln-table-compact-font-size: var(--ln-font-size-lg);
   --ln-table-compact-padding-y: 6px;
   --ln-table-compact-padding-x: 7px;
 
-  --ln-panel-head-padding-y: 14px;
-  --ln-panel-head-padding-x: 16px;
-  --ln-panel-head-compact-padding-y: 10px;
+  --ln-panel-head-padding-y: 10px;
+  --ln-panel-head-padding-x: 12px;
+  --ln-panel-head-compact-padding-y: 8px;
   --ln-panel-head-compact-padding-x: 12px;
   --ln-panel-title-size: var(--ln-font-size-title-sm);
   --ln-panel-copy-size: var(--ln-font-size-md);
@@ -95,26 +95,26 @@
 
   --ln-card-gap: 8px;
   --ln-metadata-grid-columns: 4;
-  --ln-metadata-card-min-height: 96px;
-  --ln-layout-gap: 14px;
-  --ln-layout-annotation-width: 310px;
+  --ln-metadata-card-min-height: 76px;
+  --ln-layout-gap: 10px;
+  --ln-layout-annotation-width: 330px;
   --ln-layout-annotation-collapsed-width: 56px;
   --ln-layout-annotation-max-height: calc(100vh - 104px);
   --ln-layout-preview-padding: 12px;
   --ln-layout-preview-gap: 8px;
   --ln-analysis-gap: 10px;
   --ln-workflow-column-count: 3;
-  --ln-workflow-card-padding: 14px;
+  --ln-workflow-card-padding: 11px;
   --ln-preview-card-min-width: 260px;
   --ln-workspace-width: 1380px;
-  --ln-workspace-gutter: 40px;
+  --ln-workspace-gutter: 24px;
   --ln-workspace-radius: var(--ln-radius-2xl);
-  --ln-workspace-padding: clamp(22px, 3vw, 36px);
+  --ln-workspace-padding: clamp(16px, 2vw, 24px);
 
   --ln-plate-cell-min-width: 54px;
   --ln-plate-cell-height: 51px;
   --ln-plate-cell-padding: 7px 7px 6px 9px;
-  --ln-plate-canvas-padding: 18px;
+  --ln-plate-canvas-padding: 14px;
   --ln-plate-viewport-height: clamp(470px, 58vh, 620px);
   --ln-plate-selection-fill: rgba(29, 76, 80, .13);
   --ln-plate-selection-line: #1d4c50;
@@ -125,7 +125,7 @@
   --ln-annotation-label-size: var(--ln-font-size-lg);
   --ln-chart-label-max-height: 54px;
 
-  --ln-shadow-panel: 0 22px 58px rgba(72, 58, 43, .12);
+  --ln-shadow-panel: 0 8px 24px rgba(35, 54, 47, .07);
 
   font-family: var(--ln-font-sans);
   color: var(--ln-color-ink);
@@ -157,7 +157,9 @@
 }
 
 * { box-sizing: border-box; }
-body { margin: 0; min-width: 320px; min-height: 100vh; background: var(--canvas); }
+html { color-scheme: light; scrollbar-color: var(--ln-color-line-strong) transparent; }
+body { margin: 0; min-width: 320px; min-height: 100vh; background: var(--canvas); -webkit-font-smoothing: antialiased; text-rendering: optimizeLegibility; }
+::selection { color: var(--ln-color-primary-strong); background: rgba(32,81,86,.16); }
 button, input, select, textarea { font: inherit; }
 button { cursor: pointer; }
 button:disabled { cursor: not-allowed; opacity: .45; }
@@ -165,67 +167,67 @@ input, select, textarea {
   width: 100%; min-height: var(--ln-control-height); padding: var(--ln-control-padding-y) var(--ln-control-padding-x); border: 1px solid var(--line); border-radius: var(--ln-radius-md);
   outline: 0; color: var(--ink); background: white;
 }
-input:focus, select:focus, textarea:focus { border-color: #1d4c50; box-shadow: 0 0 0 3px rgba(29,76,80,.13); }
+input:focus, select:focus, textarea:focus { border-color: var(--ln-color-primary); box-shadow: 0 0 0 3px rgba(32,81,86,.12); }
+button:focus-visible { outline: 2px solid var(--ln-color-primary); outline-offset: 2px; }
 
 .app-shell { min-height: 100vh; }
 .topbar {
-  position: sticky; top: 0; z-index: 50; height: 68px; display: flex; align-items: center; justify-content: space-between;
-  gap: 18px; padding: 0 clamp(18px, 4vw, 64px); color: white; background: rgba(29,76,80,.98);
+  position: sticky; top: 0; z-index: 50; height: 56px; display: flex; align-items: center; justify-content: space-between;
+  gap: 16px; padding: 0 clamp(16px, 3vw, 44px); color: white; background: rgba(23,59,62,.98);
   border-bottom: 1px solid rgba(255,245,232,.14); backdrop-filter: blur(16px);
 }
 .brand { display: flex; align-items: center; gap: 11px; padding: 0; border: 0; color: inherit; background: transparent; text-align: left; }
 .brand strong, .brand small { display: block; }
 .brand strong { font-size: var(--ln-font-size-title-md); letter-spacing: -.015em; }
 .brand small { margin-top: 2px; color: rgba(255,255,255,.52); font-size: var(--ln-font-size-sm); letter-spacing: .06em; text-transform: uppercase; }
-.brand-mark { width: 36px; height: 36px; display: flex; align-items: flex-end; justify-content: center; gap: 3px; padding: 8px; border-radius: 11px; background: linear-gradient(145deg,#dda278,#9a6f43); box-shadow: 0 10px 24px rgba(100,72,44,.28); }
+.brand-mark { width: 30px; height: 30px; display: flex; align-items: flex-end; justify-content: center; gap: 3px; padding: 6px; border-radius: var(--ln-radius-md); background: var(--ln-color-accent); box-shadow: none; }
 .brand-mark i { width: 3px; border-radius: 3px; background: white; }
 .brand-mark i:nth-child(1) { height: 8px; opacity: .5; }.brand-mark i:nth-child(2) { height: 15px; opacity: .75; }.brand-mark i:nth-child(3) { height: 20px; }.brand-mark i:nth-child(4) { height: 11px; opacity: .65; }
 .topbar-actions { display: flex; align-items: center; gap: 8px; }
-.privacy-pill, .status-pill, .adapter-badge, .readiness { display: inline-flex; align-items: center; gap: 7px; padding: 7px 10px; border-radius: var(--ln-radius-pill); font-size: var(--ln-font-size-sm); font-weight: 700; }
+.privacy-pill, .status-pill, .adapter-badge, .readiness { display: inline-flex; align-items: center; gap: 6px; padding: 5px 9px; border-radius: var(--ln-radius-pill); font-size: var(--ln-font-size-sm); font-weight: 700; }
 .privacy-pill { color: #f1d6bd; border: 1px solid rgba(221,162,120,.35); background: rgba(221,162,120,.12); }
 .privacy-pill i { width: 6px; height: 6px; border-radius: 50%; background: #dda278; box-shadow: 0 0 0 4px rgba(221,162,120,.13); }
 .status-pill { color: rgba(255,255,255,.78); border: 1px solid rgba(255,245,232,.18); }.status-pill.ready { color: #dceee7; border-color: rgba(129,183,163,.34); }
 
-main { padding-bottom: 70px; }
-.assay-strip { padding: 42px clamp(20px,4vw,64px) 34px; color: #fdf8ef; background: linear-gradient(135deg,#2f6a6b 0%,#3f675d 62%,#8a745a 100%); }
+main { padding-bottom: 40px; }
+.assay-strip { padding: 22px clamp(16px,3vw,44px) 18px; color: #f7faf8; background: linear-gradient(118deg,#205156 0%,#345f58 72%,#59665a 100%); }
 .assay-strip > div:first-child { max-width: 1200px; }
-.eyebrow { margin: 0 0 var(--ln-space-3); color: #1d4c50; font-size: var(--ln-font-size-sm); font-weight: 850; letter-spacing: .16em; text-transform: uppercase; }
-.assay-strip .eyebrow { color: #f0c6a4; }
 .assay-strip h1 { max-width: 1200px; margin: 0; font-size: var(--ln-font-size-hero); line-height: 1.18; letter-spacing: -.035em; font-weight: 660; }
-.assay-cards { display: grid; grid-template-columns: repeat(6,minmax(150px,1fr)); gap: var(--ln-card-gap); margin-top: var(--ln-space-12); overflow-x: auto; padding-bottom: var(--ln-space-1); }
-.assay-card { position: relative; min-height: 112px; padding: var(--ln-space-6); border: 1px solid rgba(255,245,232,.2); border-radius: 11px; color: white; background: rgba(22,54,52,.24); text-align: left; transition: border-color .16s ease, background .16s ease, transform .16s ease; }
+.assay-cards { display: grid; grid-template-columns: repeat(7,minmax(126px,1fr)); gap: var(--ln-card-gap); margin-top: var(--ln-space-6); overflow-x: auto; padding-bottom: var(--ln-space-1); }
+.assay-card { position: relative; min-height: 78px; padding: var(--ln-space-4) var(--ln-space-5); border: 1px solid rgba(255,255,255,.16); border-radius: var(--ln-radius-lg); color: white; background: rgba(15,48,48,.2); text-align: left; transition: border-color .16s ease, background .16s ease, transform .16s ease; }
 .assay-card span, .assay-card strong, .assay-card small, .assay-card em { display: block; }
 .assay-card span { color: #eec5a6; font-size: var(--ln-font-size-lg); font-weight: 850; letter-spacing: .04em; }
-.assay-card strong { margin-top: 13px; font-size: var(--ln-font-size-title-md); line-height: var(--ln-line-height-tight); }.assay-card small { margin-top: var(--ln-space-2); color: rgba(255,255,255,.68); font-size: var(--ln-font-size-md); line-height: 1.35; }
+.assay-card strong { margin-top: var(--ln-space-1); font-size: var(--ln-font-size-title-sm); line-height: var(--ln-line-height-tight); }.assay-card small { overflow: hidden; margin-top: 3px; color: rgba(255,255,255,.68); font-size: var(--ln-font-size-sm); line-height: 1.3; text-overflow: ellipsis; white-space: nowrap; }
 .assay-card.complete:hover,.assay-card.preview:hover { border-color: rgba(248,207,171,.58); transform: translateY(-1px); }
-.assay-card em { margin-top: var(--ln-space-3); color: #f6d2b4; font-size: var(--ln-font-size-xs); font-style: normal; font-weight: 800; }
+.assay-card em { margin-top: 3px; color: #f2d3bd; font-size: var(--ln-font-size-xs); font-style: normal; font-weight: 750; }
 .assay-card.preview em { color: #d7e6df; }
-.assay-card.active { border-color: #f2c39d; background: linear-gradient(145deg,rgba(19,59,62,.72),rgba(138,99,65,.62)); box-shadow: inset 0 1px 0 rgba(255,255,255,.18),0 8px 22px rgba(20,47,45,.18); }
-.assay-card.active::after { content:"✓"; position:absolute; top:10px; right:10px; display:grid; place-items:center; width:18px; height:18px; border-radius:50%; color:#264b49; background:#f2c39d; font-size:10px; font-weight:900; }
+.assay-card.active { border-color: rgba(241,211,190,.8); background: rgba(13,53,55,.66); box-shadow: inset 3px 0 0 var(--ln-color-accent); }
+.assay-card.active::after { content:"✓"; position:absolute; top:8px; right:8px; color:#f1d3be; font-size:12px; font-weight:900; }
 .assay-card.planned { border-color: rgba(189,174,173,.24); background: rgba(189,174,173,.16); opacity: .72; }
 
-.workspace-nav { width: min(var(--ln-workspace-width),calc(100% - var(--ln-workspace-gutter))); margin: var(--ln-space-8) auto 0; display: flex; gap: var(--ln-space-2); }
-.workspace-nav button { display: inline-flex; align-items: center; gap: var(--ln-space-3); padding: 9px var(--ln-space-5); border: 0; border-radius: var(--ln-radius-md); color: var(--muted); background: transparent; font-size: var(--ln-font-size-lg); font-weight: 700; }
+.workspace-nav { width: min(var(--ln-workspace-width),calc(100% - var(--ln-workspace-gutter))); margin: var(--ln-space-3) auto 0; display: flex; gap: var(--ln-space-2); }
+.workspace-nav button { display: inline-flex; align-items: center; gap: var(--ln-space-3); min-height: 34px; padding: 6px var(--ln-space-5); border: 0; border-radius: var(--ln-radius-md); color: var(--muted); background: transparent; font-size: var(--ln-font-size-lg); font-weight: 700; }
 .workspace-nav button span { width: 20px; height: 20px; display: grid; place-items: center; border-radius: 50%; color: #887c70; background: #ebe3da; font-size: var(--ln-font-size-xs); }
-.workspace-nav button.active { color: var(--violet-dark); background: white; box-shadow: 0 4px 15px rgba(83,68,50,.08); }.workspace-nav button.active span { color: white; background: var(--violet); }
+.workspace-nav button.active { color: var(--violet-dark); background: white; box-shadow: 0 2px 8px rgba(35,54,47,.06); }.workspace-nav button.active span { color: white; background: var(--violet); }
 .notice { width: min(var(--ln-workspace-width),calc(100% - var(--ln-workspace-gutter))); margin: var(--ln-space-5) auto 0; padding: var(--ln-space-4) 13px; border-radius: 9px; font-size: var(--ln-font-size-lg); line-height: var(--ln-line-height-relaxed); }
 .notice.success { color: var(--success); border: 1px solid #c7ddd1; background: var(--success-soft); }.notice.warning { display: flex; justify-content: space-between; color: var(--warning); border: 1px solid #ead1aa; background: var(--warning-soft); }
 .notice button { border: 0; color: inherit; background: transparent; }
 
-.workspace { width: min(var(--ln-workspace-width),calc(100% - var(--ln-workspace-gutter))); margin: var(--ln-space-7) auto 0; padding: var(--ln-workspace-padding); border: 1px solid rgba(255,255,255,.85); border-radius: var(--ln-workspace-radius); background: rgba(255,255,255,.98); box-shadow: var(--shadow); }
-.section-heading { margin-bottom: 24px; }.section-heading.split { display: flex; justify-content: space-between; gap: 28px; align-items: flex-start; }
-.section-heading h2 { margin: 0; font-size: var(--ln-font-size-title-xl); letter-spacing: -.035em; }.section-heading p:last-child { max-width: 760px; margin: var(--ln-space-3) 0 0; color: var(--muted); font-size: var(--ln-font-size-lg); line-height: var(--ln-line-height-copy); }
+.workspace { width: min(var(--ln-workspace-width),calc(100% - var(--ln-workspace-gutter))); margin: var(--ln-space-3) auto 0; padding: var(--ln-workspace-padding); border: 1px solid var(--line); border-radius: var(--ln-workspace-radius); background: rgba(255,255,255,.98); box-shadow: var(--shadow); }
+.section-heading { margin-bottom: var(--ln-space-6); }.section-heading.split { display: flex; justify-content: space-between; gap: var(--ln-space-9); align-items: flex-start; }
+.section-heading h2 { margin: 0; font-size: var(--ln-font-size-title-xl); letter-spacing: -.025em; }.section-heading p:last-child { max-width: 820px; margin: var(--ln-space-2) 0 0; color: var(--muted); font-size: var(--ln-font-size-lg); line-height: var(--ln-line-height-relaxed); }
 .adapter-badge { color: #1d4c50; border: 1px solid #c6d8d5; background: var(--violet-soft); }
 .import-heading-actions,.analysis-heading-actions,.assay-export-actions { display: flex; flex-wrap: wrap; align-items: center; justify-content: flex-end; gap: var(--ln-space-2); }
 .inline-actions, .export-actions { display: flex; flex-wrap: wrap; gap: 8px; }
 .template-select { width: auto; min-width: 142px; min-height: var(--ln-button-height); padding: var(--ln-button-padding-y) 28px var(--ln-button-padding-y) var(--ln-control-padding-x); border-color: #dfc0a6; color: #774f30; background: var(--ln-color-surface-warm); font-size: var(--ln-font-size-md); font-weight: 750; }
 .primary-button, .secondary-button, .export-actions button { min-height: var(--ln-button-height); padding: var(--ln-button-padding-y) var(--ln-button-padding-x); border-radius: var(--ln-radius-md); font-size: var(--ln-font-size-md); font-weight: 750; }
-.primary-button { border: 1px solid var(--violet); color: white; background: var(--violet); box-shadow: 0 8px 20px rgba(29,76,80,.2); }.primary-button:hover { background: var(--violet-dark); }.primary-button.full { width: 100%; margin-top: 14px; }
-.secondary-button, .export-actions button { border: 1px solid #dfc0a6; color: #774f30; background: #fff2e6; }.secondary-button:hover, .export-actions button:hover { background: #f8e4d1; }
+.primary-button { border: 1px solid var(--violet); color: white; background: var(--violet); box-shadow: none; }.primary-button:hover { background: var(--violet-dark); }.primary-button.full { width: 100%; margin-top: 12px; }
+.secondary-button, .export-actions button { border: 1px solid var(--line-strong); color: var(--graphite); background: var(--ln-color-surface); }.secondary-button:hover, .export-actions button:hover { border-color: var(--violet); color: var(--violet-dark); background: var(--violet-soft); }
+.primary-button:active,.secondary-button:active,.export-actions button:active { transform: translateY(1px); }
 .export-actions button:disabled { border-color: #ded1d0; color: #9c8d8b; background: var(--reed-gray-soft); }
 
-.dropzone { width: 100%; min-height: 105px; display: grid; grid-template-columns: 48px minmax(0,1fr) auto; align-items: center; gap: 15px; padding: var(--ln-space-8); border: 1px dashed #aeb9b5; border-radius: var(--ln-radius-xl); color: var(--graphite); background: #f8faf9; text-align: left; }
-.dropzone:hover { border-color: #dda278; background: #fff6ed; }.dropzone-icon { width: 46px; height: 46px; display: grid; place-items: center; border-radius: var(--ln-radius-lg); color: white; background: var(--violet); font-size: var(--ln-font-size-sm); font-weight: 850; }.dropzone strong,.dropzone small { display: block; }.dropzone strong { font-size: var(--ln-font-size-title-sm); }.dropzone small { margin-top: 5px; color: var(--muted); font-size: var(--ln-font-size-md); }.dropzone b { color: #9a6f43; font-size: var(--ln-font-size-md); }
+.dropzone { width: 100%; min-height: 84px; display: grid; grid-template-columns: 42px minmax(0,1fr) auto; align-items: center; gap: var(--ln-space-5); padding: var(--ln-space-5); border: 1px dashed #aeb9b5; border-radius: var(--ln-radius-lg); color: var(--graphite); background: #f8faf9; text-align: left; }
+.dropzone:hover { border-color: var(--violet); background: var(--violet-soft); }.dropzone-icon { width: 40px; height: 40px; display: grid; place-items: center; border-radius: var(--ln-radius-md); color: white; background: var(--violet); font-size: var(--ln-font-size-sm); font-weight: 850; }.dropzone strong,.dropzone small { display: block; }.dropzone strong { font-size: var(--ln-font-size-title-sm); }.dropzone small { margin-top: 3px; color: var(--muted); font-size: var(--ln-font-size-md); }.dropzone b { color: var(--violet); font-size: var(--ln-font-size-md); }
 .import-source-tabs { display: grid; grid-template-columns: repeat(3,minmax(0,1fr)); gap: var(--ln-space-2); margin-bottom: var(--ln-space-5); padding: var(--ln-space-1); border: 1px solid var(--line); border-radius: var(--ln-radius-lg); background: var(--ln-color-surface-warm); }
 .assay-workflow-panel { margin-bottom: var(--ln-space-6); overflow: hidden; border: 1px solid var(--line); border-radius: var(--ln-radius-xl); background: var(--ln-color-surface-warm); }
 .assay-workflow-header { display: flex; align-items: flex-start; justify-content: space-between; gap: var(--ln-space-8); padding: var(--ln-workflow-card-padding); border-bottom: 1px solid var(--line); background: var(--ln-color-panel-head); }
@@ -476,4 +478,135 @@ main { padding-bottom: 70px; }
 .selected-preview p {
   font-size: var(--ln-annotation-copy-size);
   line-height: var(--ln-line-height-normal);
+}
+
+/* Compact scientific workspace: one restrained surface hierarchy, token-driven. */
+.panel {
+  border-radius: var(--ln-radius-lg);
+}
+
+.panel-head {
+  min-height: 48px;
+  gap: var(--ln-space-6);
+}
+
+.metric {
+  min-height: var(--ln-metadata-card-min-height);
+  padding: var(--ln-space-4) var(--ln-space-5);
+  border: 0;
+  border-radius: var(--ln-radius-xs);
+  background: var(--ln-color-surface-warm);
+}
+
+.metric span {
+  letter-spacing: .03em;
+  text-transform: none;
+}
+
+.metric strong,
+.metric small {
+  margin-top: var(--ln-space-1);
+}
+
+.well {
+  border-color: rgba(67,81,74,.2);
+  border-radius: var(--ln-radius-sm);
+  box-shadow: inset 0 1px 0 rgba(255,255,255,.36);
+  transition: border-color .14s ease, background-color .14s ease;
+}
+
+.well:hover {
+  border-color: var(--ln-color-primary);
+  transform: none;
+}
+
+.well.selected {
+  outline-color: rgba(32,81,86,.48);
+  outline-offset: 1px;
+}
+
+.plate-legend {
+  gap: 6px 13px;
+  padding: 8px 12px;
+  font-size: var(--ln-font-size-sm);
+}
+
+.annotation-panel {
+  top: 66px;
+}
+
+.annotation-panel-toggle {
+  width: 32px;
+  min-width: 32px;
+  height: 32px;
+}
+
+.next-step {
+  gap: var(--ln-space-7);
+  margin-top: var(--ln-space-4);
+  padding: var(--ln-space-4) var(--ln-space-5);
+  border: 0;
+  border-top: 1px solid var(--line);
+  border-radius: 0;
+}
+
+.export-panel {
+  gap: var(--ln-space-8);
+  margin-top: var(--ln-space-4);
+  padding: var(--ln-space-5);
+  border-color: var(--line);
+  border-radius: var(--ln-radius-lg);
+  background: var(--ln-color-panel-head);
+}
+
+.analysis-workspace {
+  padding: var(--ln-workspace-padding);
+}
+
+.analysis-layout-compact {
+  grid-template-columns: 230px minmax(0,1fr);
+}
+
+.side-control-grid {
+  gap: var(--ln-space-3);
+  padding: var(--ln-space-3) var(--ln-space-4);
+}
+
+.table-scroll th {
+  background: var(--ln-color-panel-head);
+}
+
+.table-scroll td,
+.table-scroll th,
+.well strong,
+.chart-value {
+  font-variant-numeric: tabular-nums;
+}
+
+.clickable-table tbody tr:hover,
+.qc-mini-list li:hover {
+  background: var(--ln-color-primary-soft);
+}
+
+.clickable-table tbody tr.selected-row {
+  background: #edf3f0;
+}
+
+.method-note {
+  padding: var(--ln-space-3) var(--ln-space-4);
+  background: var(--ln-color-surface-warm);
+}
+
+@media (max-width: 1100px) {
+  .assay-cards { grid-template-columns: repeat(7,160px); }
+}
+
+@media (max-width: 720px) {
+  .assay-strip { padding: 18px 14px 14px; }
+  .workspace,.workspace-nav,.notice { width: calc(100% - 16px); }
+  .workspace { padding: 14px 10px; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,*::before,*::after { scroll-behavior: auto !important; transition-duration: .01ms !important; animation-duration: .01ms !important; animation-iteration-count: 1 !important; }
 }


### PR DESCRIPTION
Closes #21.

## What changed
- Reworked the global `--ln-*` tokens for a denser, quieter scientific-instrument visual system.
- Reduced the top bar and assay-selection banner while keeping all seven assay modules visible in a compact rail.
- Tightened workspace headings, controls, panels, metadata, plate maps, annotation forms, analysis tables, charts, and export areas.
- Raised tiny copy to a readable scale while reducing empty space and control height.
- Removed redundant section eyebrow labels and decorative card effects.
- Added consistent focus, active, numeric alignment, selection, scrollbar, and reduced-motion behavior.
- Replaced ambiguous dash placeholders with explicit states such as “未记录”.
- Added browser regression checks for banner/topbar height, readable copy, removed eyebrow labels, and narrow-screen overflow.
- Bumped the standalone tool to v0.5.4.

## Scientific and product boundaries
- No calculation, raw measurement, statistical, annotation, import, or export semantics changed.
- The existing information architecture and browser-local behavior are preserved.

## Verification
- TypeScript typecheck
- 36 unit tests
- Production and single-file offline builds
- Browser acceptance flow at desktop and narrow widths
- Real CCK-8 fixture validation
- Offline Chromium smoke test
- Impeccable anti-pattern detector (single final pass; flagged side-tab accent removed)