### PR TITLE
Distill assay workflow guidance below import controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Microplate Assay Studio
 
-面向酶标仪/多功能微孔板读数仪的一体化分析工作台。当前版本为 v0.5.4，使用真实 Thermo Scientific Varioskan LUX / SkanIt XML、XLSX 和旧版 VICTOR XLS 数据开发。
+面向酶标仪/多功能微孔板读数仪的一体化分析工作台。当前版本为 v0.5.5，使用真实 Thermo Scientific Varioskan LUX / SkanIt XML、XLSX 和旧版 VICTOR XLS 数据开发。
 
 ## 工具定位
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "microplate-assay-studio",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "microplate-assay-studio",
-      "version": "0.5.4",
+      "version": "0.5.5",
       "dependencies": {
         "react": "19.2.6",
         "react-dom": "19.2.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "microplate-assay-studio",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "private": true,
   "type": "module",
   "engines": {

--- a/scripts/visual-smoke.mjs
+++ b/scripts/visual-smoke.mjs
@@ -16,10 +16,20 @@ try {
     if (!landingText.includes(signal)) throw new Error(`Module capability states are missing: ${signal}`);
   }
   await page.getByRole("button", { name: /蛋白定量/ }).click();
+  const workflowDisclosure = page.locator(".assay-workflow-panel.compact-workflow");
+  if (await workflowDisclosure.count() !== 1) throw new Error("Compact assay guidance disclosure is missing from the import workspace.");
+  if (await workflowDisclosure.getAttribute("open") !== null) throw new Error("Assay guidance should be collapsed by default.");
+  const importControlBounds = await page.locator(".dropzone").boundingBox();
+  const workflowDisclosureBounds = await workflowDisclosure.boundingBox();
+  if (!importControlBounds || !workflowDisclosureBounds || workflowDisclosureBounds.y <= importControlBounds.y) {
+    throw new Error("Assay guidance is not positioned below the active import control.");
+  }
+  await workflowDisclosure.locator("summary").click();
   const proteinText = await page.locator("body").innerText();
   for (const signal of ["标准品浓度和单位", "仪器标准曲线核查", "本系统标准曲线复算"]) {
     if (!proteinText.includes(signal)) throw new Error(`Protein workflow guidance is missing: ${signal}`);
   }
+  await page.screenshot({ path: resolve(screenshotDir, "microplate-studio-guidance-expanded.png"), fullPage: true });
   for (const tabName of ["仪器结果文件", "粘贴孔板读数", "读数模板"]) {
     if (!await page.getByRole("tab", { name: tabName }).isVisible()) throw new Error(`Shared import tab is missing from protein workflow: ${tabName}`);
   }
@@ -28,7 +38,14 @@ try {
   await page.getByRole("button", { name: /单 \/ 双荧光素酶/ }).click();
   if (!(await page.locator("body").innerText()).includes("Firefly 与 Renilla 步骤映射")) throw new Error("Luciferase-specific workflow guidance is missing.");
   await page.getByRole("button", { name: /细胞活性 \/ 细胞增殖/ }).click();
+  if (await workflowDisclosure.getAttribute("open") !== null) await workflowDisclosure.locator("summary").click();
+  if (!(await workflowDisclosure.innerText()).includes("支持吸光、荧光和发光型细胞活性读数")) throw new Error("Cell-viability guidance does not name all supported detection modes.");
   await page.screenshot({ path: resolve(screenshotDir, "microplate-studio-start.png"), fullPage: true });
+  await page.setViewportSize({ width: 980, height: 1000 });
+  const importOverflow = await page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth);
+  if (importOverflow > 1) throw new Error(`Compact import workspace has ${importOverflow}px of page-level horizontal overflow.`);
+  await page.screenshot({ path: resolve(screenshotDir, "microplate-studio-import-narrow.png"), fullPage: true });
+  await page.setViewportSize({ width: 1440, height: 1100 });
   const topbarBounds = await page.locator(".topbar").boundingBox();
   const assayStripBounds = await page.locator(".assay-strip").boundingBox();
   const sectionCopySize = Number.parseFloat(await page.locator(".section-heading p").first().evaluate((element) => getComputedStyle(element).fontSize));

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -584,16 +584,6 @@ export default function App() {
           <div><h2>导入孔板读数</h2><p>当前模块：{selectedModule.name} · {selectedModule.measurementTarget}。可以导入仪器结果，也可以粘贴 Excel 矩阵或填写标准读数模板；全部数据只在浏览器本地处理。</p></div>
           <div className="import-heading-actions">{plate ? <><span className="adapter-badge">{plate.metadata.adapterId}</span><button type="button" className="secondary-button mini" onClick={downloadProjectFile}>保存可复现项目</button></> : null}<input ref={projectInput} hidden type="file" accept=".json" onChange={(event) => { const file = event.target.files?.[0]; if (file) void previewProjectFile(file); event.target.value = ""; }} /><button type="button" className="secondary-button mini" onClick={() => projectInput.current?.click()}>重新打开项目文件</button></div>
         </div>
-        <AssayWorkflowPanel module={selectedModule} plate={plate && activeModuleId === selectedModuleId ? plate : null} />
-        <details className="experiment-record" open={Boolean(experiment.name || experiment.operator || experiment.date || experiment.notes)}>
-          <summary>实验记录信息 <small>随可复现项目和溯源导出保存</small></summary>
-          <div className="experiment-record-grid">
-            <Field label="实验名称"><input value={experiment.name} onChange={(event) => updateExperiment({ name: event.target.value })} placeholder="例如 Drug response · Day 2" /></Field>
-            <Field label="操作者"><input value={experiment.operator} onChange={(event) => updateExperiment({ operator: event.target.value })} /></Field>
-            <Field label="实验日期"><input type="date" value={experiment.date} onChange={(event) => updateExperiment({ date: event.target.value })} /></Field>
-            <Field label="项目备注"><input value={experiment.notes} onChange={(event) => updateExperiment({ notes: event.target.value })} /></Field>
-          </div>
-        </details>
         <div className="import-source-tabs" role="tablist" aria-label="孔板读数来源">
           <button type="button" role="tab" aria-selected={importMode === "instrument"} className={importMode === "instrument" ? "active" : ""} onClick={() => { setImportMode("instrument"); setPendingBatch(null); }}>仪器结果文件</button>
           <button type="button" role="tab" aria-selected={importMode === "paste"} className={importMode === "paste" ? "active" : ""} onClick={() => { setImportMode("paste"); setPendingBatch(null); }}>粘贴孔板读数</button>
@@ -627,6 +617,17 @@ export default function App() {
             <button type="button" className="dropzone compact-dropzone" disabled={loading} onClick={() => readingTemplateInput.current?.click()}><span className="dropzone-icon">XLSX</span><span><strong>{loading ? "正在解析…" : "导入已填写的读数模板"}</strong><small>每块板使用一个工作表；也支持一个工作表内连续排列多个固定矩阵。</small></span><b>Browse</b></button>
           </>}
         </div>}
+
+        <AssayWorkflowPanel variant="disclosure" module={selectedModule} plate={plate && activeModuleId === selectedModuleId ? plate : null} />
+        <details className="experiment-record" open={Boolean(experiment.name || experiment.operator || experiment.date || experiment.notes)}>
+          <summary>实验记录信息 <small>随可复现项目和溯源导出保存</small></summary>
+          <div className="experiment-record-grid">
+            <Field label="实验名称"><input value={experiment.name} onChange={(event) => updateExperiment({ name: event.target.value })} placeholder="例如 Drug response · Day 2" /></Field>
+            <Field label="操作者"><input value={experiment.operator} onChange={(event) => updateExperiment({ operator: event.target.value })} /></Field>
+            <Field label="实验日期"><input type="date" value={experiment.date} onChange={(event) => updateExperiment({ date: event.target.value })} /></Field>
+            <Field label="项目备注"><input value={experiment.notes} onChange={(event) => updateExperiment({ notes: event.target.value })} /></Field>
+          </div>
+        </details>
 
         {pendingBatch ? <div className="import-preview" aria-label="导入预览">
           <div className="import-preview-head"><div><h3>导入预览与实验类型确认</h3><p>识别到 {pendingBatch.plates.length} 块独立孔板；确认后才会替换当前工作区。</p></div><span>{pendingBatch.sourceKind === "manual-paste" ? "人工粘贴" : pendingBatch.sourceKind === "reading-template" ? "读数模板" : pendingBatch.sourceKind === "project-file" ? "可复现项目" : "仪器文件"}</span></div>

--- a/src/components/AssayWorkflowPanel.tsx
+++ b/src/components/AssayWorkflowPanel.tsx
@@ -5,19 +5,42 @@ export function assayStatusLabel(status: AssayModuleDefinition["status"]): strin
   return status === "complete" ? "完整分析可用" : status === "preview" ? "数据导入与预览可用" : "计划中";
 }
 
-export function AssayWorkflowPanel({ module, plate }: { module: AssayModuleDefinition; plate?: ParsedPlate | null }) {
+type AssayWorkflowPanelProps = {
+  module: AssayModuleDefinition;
+  plate?: ParsedPlate | null;
+  variant?: "expanded" | "disclosure";
+};
+
+function WorkflowDetails({ module, facts }: { module: AssayModuleDefinition; facts: ReturnType<typeof assayWorkflowFacts> }) {
+  return <div className="assay-workflow-details">
+    <div className="assay-workflow-columns">
+      <div><strong>需要确认</strong><p>{module.requiredInformation.join("、")}</p></div>
+      <div><strong>本系统可完成</strong><p>{module.availableAnalyses.length ? module.availableAnalyses.join("、") : "尚未开放分析"}</p></div>
+      {module.deferredAnalyses.length ? <div><strong>暂不计算</strong><p>{module.deferredAnalyses.join("、")}</p></div> : null}
+    </div>
+    {facts.length ? <div className="assay-workflow-facts">{facts.map((fact) => <div key={fact.label}><span>{fact.label}</span><strong>{fact.value}</strong><small className={fact.evidence}>{fact.evidence === "instrument" ? "仪器提供" : fact.evidence === "user" ? "用户填写" : "需要补充"}</small></div>)}</div> : null}
+    <p className="annotation-guidance"><strong>板图注释：</strong>{module.annotationGuidance}</p>
+  </div>;
+}
+
+export function AssayWorkflowPanel({ module, plate, variant = "expanded" }: AssayWorkflowPanelProps) {
   const facts = plate ? assayWorkflowFacts(plate, module.id) : [];
+
+  if (variant === "disclosure") {
+    return <details className="assay-workflow-panel compact-workflow" aria-label={`${module.name}分析说明`}>
+      <summary>
+        <span className="workflow-summary-copy"><strong>分析说明</strong><span>{module.name}：{module.description}</span></span>
+        <span className="workflow-summary-meta"><span className={`capability-status ${module.status}`}>{assayStatusLabel(module.status)}</span><span className="workflow-detection-modes">{module.detectionModes.join(" / ")}</span><span className="workflow-disclosure-action">查看</span></span>
+      </summary>
+      <WorkflowDetails module={module} facts={facts} />
+    </details>;
+  }
+
   return <section className="assay-workflow-panel" aria-label={`${module.name}工作流说明`}>
     <div className="assay-workflow-header">
       <div><span className={`capability-status ${module.status}`}>{assayStatusLabel(module.status)}</span><h3>{module.name}</h3><p>{module.description}</p></div>
       <div className="mode-pills">{module.detectionModes.map((mode) => <span key={mode}>{mode}</span>)}</div>
     </div>
-    <div className="assay-workflow-columns">
-      <div><strong>导入后需要确认</strong><ul>{module.requiredInformation.map((item) => <li key={item}>{item}</li>)}</ul></div>
-      <div><strong>当前可以完成</strong>{module.availableAnalyses.length ? <ul>{module.availableAnalyses.map((item) => <li key={item}>{item}</li>)}</ul> : <p>尚未开放分析。</p>}</div>
-      <div><strong>尚未由本系统计算</strong>{module.deferredAnalyses.length ? <ul>{module.deferredAnalyses.map((item) => <li key={item}>{item}</li>)}</ul> : <p>无</p>}</div>
-    </div>
-    {facts.length ? <div className="assay-workflow-facts">{facts.map((fact) => <div key={fact.label}><span>{fact.label}</span><strong>{fact.value}</strong><small className={fact.evidence}>{fact.evidence === "instrument" ? "仪器提供" : fact.evidence === "user" ? "用户填写" : "需要补充"}</small></div>)}</div> : null}
-    <p className="annotation-guidance"><strong>注释建议：</strong>{module.annotationGuidance}</p>
+    <WorkflowDetails module={module} facts={facts} />
   </section>;
 }

--- a/src/core/assay-workflows.ts
+++ b/src/core/assay-workflows.ts
@@ -11,7 +11,7 @@ export const assayModules: AssayModuleDefinition[] = [
     shortName: "CCK-8 · MTT · alamarBlue",
     name: "细胞活性 / 细胞增殖",
     measurementTarget: "细胞代谢活性与相对存活/增殖",
-    description: "兼容吸光、荧光等读数；区分具体方法、原始信号、空白处理、重复层级与对照归一化。",
+    description: "支持吸光、荧光和发光型细胞活性读数，并按具体方法处理空白、重复与对照归一化。",
     detectionModes: ["absorbance", "fluorescence", "luminescence"],
     status: "complete",
     supportedMethods: ["CCK-8 / WST-8", "MTT", "Resazurin / alamarBlue"],
@@ -168,7 +168,7 @@ export function assayWorkflowFacts(plate: ParsedPlate, moduleId: AssayModuleId):
     const maxTime = Math.max(0, ...kinetics.flatMap((series) => series.points.map((point) => point.timeSeconds ?? 0)));
     return [
       { label: "读取模式", value: kinetics.length ? `动力学 · ${kinetics.length} 个步骤` : "终点/归约步骤", evidence: "instrument" },
-      { label: "时间范围", value: maxTime ? `0–${maxTime.toLocaleString()} s` : "未确认", evidence: maxTime ? "instrument" : "missing" },
+      { label: "时间范围", value: maxTime ? `0-${maxTime.toLocaleString()} s` : "未确认", evidence: maxTime ? "instrument" : "missing" },
       { label: "标准曲线", value: dataset?.standardCurves.length ? `${dataset.standardCurves.length} 条仪器曲线` : "未提供", evidence: dataset?.standardCurves.length ? "instrument" : "missing" },
       missing("积分/选取窗口"),
     ];

--- a/src/styles.css
+++ b/src/styles.css
@@ -241,6 +241,26 @@ main { padding-bottom: 40px; }
 .assay-workflow-columns strong { font-size: var(--ln-font-size-lg); }.assay-workflow-columns ul { margin: var(--ln-space-2) 0 0; padding-left: var(--ln-space-7); }.assay-workflow-columns li,.assay-workflow-columns p { margin: 3px 0; color: var(--muted); font-size: var(--ln-font-size-lg); line-height: var(--ln-line-height-normal); }
 .assay-workflow-facts { display: grid; grid-template-columns: repeat(4,minmax(0,1fr)); border-top: 1px solid var(--line); }.assay-workflow-facts > div { display: grid; gap: 3px; padding: var(--ln-space-4) var(--ln-workflow-card-padding); border-right: 1px solid var(--line); }.assay-workflow-facts > div:last-child { border-right: 0; }.assay-workflow-facts span,.assay-workflow-facts small { color: var(--muted); font-size: var(--ln-font-size-sm); }.assay-workflow-facts strong { overflow-wrap: anywhere; font-size: var(--ln-font-size-xl); }.assay-workflow-facts small.missing { color: var(--warning); }
 .annotation-guidance { margin: 0; padding: var(--ln-space-3) var(--ln-workflow-card-padding); border-top: 1px solid var(--line); color: var(--muted); background: white; font-size: var(--ln-font-size-lg); }.annotation-guidance strong { color: var(--graphite); }
+.compact-workflow { margin: var(--ln-space-4) 0 var(--ln-space-3); overflow: visible; border: 0; border-top: 1px solid var(--line); border-bottom: 1px solid var(--line); border-radius: 0; background: transparent; }
+.compact-workflow summary { display: grid; grid-template-columns: minmax(0,1fr) auto; align-items: center; gap: var(--ln-space-7); min-height: 52px; padding: var(--ln-space-3) 0; color: var(--graphite); cursor: pointer; list-style: none; }
+.compact-workflow summary::-webkit-details-marker { display: none; }
+.workflow-summary-copy { display: flex; min-width: 0; align-items: baseline; gap: var(--ln-space-4); }
+.workflow-summary-copy > strong { flex: 0 0 auto; color: var(--ink); font-size: var(--ln-font-size-title-sm); }
+.workflow-summary-copy > span { overflow: hidden; color: var(--muted); font-size: var(--ln-body-copy-size); text-overflow: ellipsis; white-space: nowrap; }
+.workflow-summary-meta { display: flex; align-items: center; gap: var(--ln-space-3); white-space: nowrap; }
+.compact-workflow .capability-status { padding: 0; border-radius: 0; background: transparent; }
+.workflow-detection-modes { color: var(--muted); font-size: var(--ln-font-size-sm); }
+.workflow-disclosure-action { min-width: 38px; color: var(--violet); font-size: var(--ln-font-size-sm); font-weight: 800; text-align: right; }
+.compact-workflow[open] .workflow-disclosure-action { font-size: 0; }
+.compact-workflow[open] .workflow-disclosure-action::after { content: "收起"; font-size: var(--ln-font-size-sm); }
+.compact-workflow .assay-workflow-details { padding: var(--ln-space-4) 0 var(--ln-space-3); border-top: 1px solid var(--line); }
+.compact-workflow .assay-workflow-columns { grid-template-columns: repeat(auto-fit,minmax(220px,1fr)); gap: var(--ln-space-8); }
+.compact-workflow .assay-workflow-columns > div { padding: 0; border: 0; }
+.compact-workflow .assay-workflow-columns strong { color: var(--ink); }
+.compact-workflow .assay-workflow-columns p { margin: var(--ln-space-1) 0 0; color: var(--muted); font-size: var(--ln-font-size-lg); line-height: var(--ln-line-height-relaxed); }
+.compact-workflow .assay-workflow-facts { margin-top: var(--ln-space-4); border: 0; border-top: 1px solid var(--line); }
+.compact-workflow .assay-workflow-facts > div { padding: var(--ln-space-3) var(--ln-space-4) 0 0; border: 0; }
+.compact-workflow .annotation-guidance { margin-top: var(--ln-space-4); padding: var(--ln-space-3) 0 0; border-top: 1px solid var(--line); background: transparent; }
 .experiment-record { margin: 0 0 var(--ln-space-5); border: 1px solid var(--line); border-radius: var(--ln-radius-lg); background: white; }.experiment-record summary { display: flex; gap: var(--ln-space-3); padding: var(--ln-space-4) var(--ln-space-5); color: var(--graphite); font-size: var(--ln-font-size-lg); font-weight: 800; cursor: pointer; }.experiment-record summary small { color: var(--muted); font-weight: 500; }.experiment-record-grid { display: grid; grid-template-columns: repeat(4,minmax(0,1fr)); gap: var(--ln-space-4); padding: 0 var(--ln-space-5) var(--ln-space-5); }
 .import-source-tabs button { min-height: var(--ln-control-height); padding: var(--ln-space-3) var(--ln-space-5); border: 0; border-radius: var(--ln-radius-md); color: var(--muted); background: transparent; font-weight: 800; }
 .import-source-tabs button.active { color: white; background: var(--violet); box-shadow: 0 6px 15px rgba(29,76,80,.18); }
@@ -311,6 +331,7 @@ main { padding-bottom: 40px; }
 }
 @media (max-width: 720px) {
   .topbar { padding:0 14px; }.privacy-pill { display:none; }.assay-strip { padding:30px 18px; }.workspace,.workspace-nav,.notice { width:calc(100% - 24px); }.workspace { padding:18px 14px; }.section-heading.split,.export-panel,.next-step { flex-direction:column; align-items:stretch; }.metadata-grid,.metric-cards,.analysis-settings,.form-grid { grid-template-columns:1fr 1fr; }.blank-form-grid { grid-template-columns:1fr; }.inline-actions,.export-actions { justify-content:flex-start; }.workspace-nav { overflow:auto; }.workspace-nav button { white-space:nowrap; }
+  .compact-workflow summary { grid-template-columns:1fr; gap:var(--ln-space-2); }.workflow-summary-copy { align-items:flex-start; flex-direction:column; gap:var(--ln-space-1); }.workflow-summary-copy > span { width:100%; white-space:normal; }.workflow-summary-meta { justify-content:space-between; }.workflow-detection-modes { overflow:hidden; text-overflow:ellipsis; }.compact-workflow .assay-workflow-columns { grid-template-columns:1fr; gap:var(--ln-space-4); }
   .manual-metadata-grid,.template-builder,.plate-switcher { grid-template-columns:1fr; }.plate-switcher label { grid-column:auto; }.manual-import-actions { align-items:stretch; flex-direction:column; }.manual-import-actions button { width:100%; }
   .layout-preview-metrics { grid-template-columns:repeat(2,minmax(0,1fr)); row-gap:var(--ln-space-3); }.layout-preview-metrics div:nth-child(3) { border-left:0; }.layout-preview-details { grid-template-columns:1fr; }.layout-preview-apply { width:100%; }.plate-panel-head { align-items:flex-start; flex-direction:column; }.plate-head-actions { width:100%; justify-content:space-between; }.plate-scroll { height:clamp(390px,58vh,520px); }.annotation-panel .quick-selects { grid-template-columns:1fr auto; }.annotation-panel .quick-selects select { grid-column:1 / -1; }
 }
@@ -375,7 +396,7 @@ main { padding-bottom: 40px; }
 .assay-step-head { align-items: center; }
 .assay-step-controls { display: grid; grid-template-columns: minmax(280px,1.3fr) minmax(220px,.7fr); gap: var(--ln-space-6); padding: var(--ln-space-5); }
 .assay-step-controls label { display: grid; gap: var(--ln-space-2); color: var(--muted); font-size: var(--ln-font-size-lg); font-weight: 750; }
-.assay-step-controls div { display: grid; align-content: center; gap: 3px; padding: var(--ln-space-3) var(--ln-space-5); border-left: 2px solid var(--ln-color-primary-soft); }
+.assay-step-controls div { display: grid; align-content: center; gap: 3px; padding: var(--ln-space-3) var(--ln-space-5); border-left: 1px solid var(--line); }
 .assay-step-controls div span { color: var(--muted); font-size: var(--ln-font-size-sm); text-transform: uppercase; }
 .assay-step-controls div strong { font-size: var(--ln-font-size-xl); }
 .assay-step-controls div small { overflow-wrap: anywhere; color: var(--muted); font-size: var(--ln-annotation-copy-size); }


### PR DESCRIPTION
Closes #23

## Changes
- Move assay guidance below the active import controls so data entry remains the primary task.
- Replace the always-expanded multi-column block with a compact disclosure that is collapsed by default.
- Preserve required inputs, supported analyses, deferred analyses, instrument facts, and plate-annotation guidance when expanded.
- Clarify that cell viability assays may use absorbance, fluorescence, or luminescence readouts.
- Add visual regression coverage for placement, disclosure behavior, narrow-screen overflow, and readout-mode copy.

## Verification
- `npm run typecheck`
- `npm run test:unit` (36 tests)
- `npm run build`
- `npm run test:browser`
- `npm run test:offline`
- `npm run test:real`
- Impeccable detector: 0 findings