### PR TITLE
Compact the analysis QC review area

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Microplate Assay Studio
 
-面向酶标仪/多功能微孔板读数仪的一体化分析工作台。当前版本为 v0.5.8，使用真实 Thermo Scientific Varioskan LUX / SkanIt XML、XLSX 和旧版 VICTOR XLS 数据开发。
+面向酶标仪/多功能微孔板读数仪的一体化分析工作台。当前版本为 v0.5.9，使用真实 Thermo Scientific Varioskan LUX / SkanIt XML、XLSX 和旧版 VICTOR XLS 数据开发。
 
 ## 工具定位
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "microplate-assay-studio",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "microplate-assay-studio",
-      "version": "0.5.8",
+      "version": "0.5.9",
       "dependencies": {
         "react": "19.2.6",
         "react-dom": "19.2.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "microplate-assay-studio",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "private": true,
   "type": "module",
   "engines": {

--- a/scripts/visual-smoke.mjs
+++ b/scripts/visual-smoke.mjs
@@ -161,6 +161,11 @@ try {
   const manualAnalysisText = await page.locator("body").innerText();
   if (!manualAnalysisText.includes("ROLE_UNASSIGNED")) throw new Error("Manual-paste analysis did not preserve the unassigned-well QC gate.");
   if (!manualAnalysisText.includes("只保留语义明确的 blank_corrected_* 基础列")) throw new Error("Analysis UI did not explain the explicit export schema.");
+  const qcFindingRows = await page.locator(".qc-mini-list li").all();
+  const qcFindingHeights = await Promise.all(qcFindingRows.map(async (row) => (await row.boundingBox())?.height ?? Number.NaN));
+  if (qcFindingHeights.some((height) => height > 84)) throw new Error(`QC findings are no longer compact: ${qcFindingHeights.join(", ")}.`);
+  const qcListBounds = await page.locator(".qc-mini-list").boundingBox();
+  if (!qcListBounds || qcListBounds.height > 300) throw new Error(`QC review list exceeded its compact height: ${qcListBounds?.height ?? "missing"}px.`);
   const wideActionButtons = await page.locator(".summary-head-actions button").all();
   const wideActionTops = await Promise.all(wideActionButtons.map(async (button) => (await button.boundingBox())?.y ?? Number.NaN));
   if (new Set(wideActionTops.map((value) => Math.round(value))).size > 1) throw new Error(`Wide summary actions are not aligned: ${wideActionTops.join(", ")}.`);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -774,9 +774,9 @@ export default function App() {
               <Field label="技术复孔 CV 阈值 (%)"><input type="number" min="0" step="1" value={config.technicalCvThresholdPercent} onChange={(event) => updateAnalysisConfig({ technicalCvThresholdPercent: Number(event.target.value) })} /></Field>
               <Field label="空白孔 CV 阈值 (%)"><input type="number" min="0" step="1" value={config.blankCvThresholdPercent} onChange={(event) => updateAnalysisConfig({ blankCvThresholdPercent: Number(event.target.value) })} /></Field>
             </div>
-            <div className="qc-compact-block">
-              <div className="side-section-title"><strong>质量控制</strong><span>{analysis.findings.length} 条</span></div>
-              {analysis.findings.length ? <ul className="qc-mini-list">{analysis.findings.map((finding, index) => <li key={`${finding.code}-${index}`} className={finding.severity} onClick={() => finding.wells.length && updatePlateSelection(new Set(finding.wells), finding.wells.at(-1) ?? null)}><span>{finding.severity}</span><div><strong>{finding.code}</strong><p>{finding.message}</p>{finding.wells.length ? <small>{finding.wells.slice(0, 8).join(", ")}{finding.wells.length > 8 ? "…" : ""}</small> : null}</div></li>)}</ul> : <div className="empty-state compact">没有发现需要复核的问题。</div>}
+            <div className={`qc-compact-block ${analysis.findings.length ? "has-findings" : "clear"}`}>
+              <div className="side-section-title"><strong>质量控制</strong><span>{analysis.findings.length ? `${analysis.findings.length} 条` : "无需复核"}</span></div>
+              {analysis.findings.length ? <ul className="qc-mini-list">{analysis.findings.map((finding, index) => <li key={`${finding.code}-${index}`} className={finding.severity} onClick={() => finding.wells.length && updatePlateSelection(new Set(finding.wells), finding.wells.at(-1) ?? null)}><span>{finding.severity}</span><div><strong>{finding.code}</strong><p title={finding.message}>{finding.message}</p>{finding.wells.length ? <small title={finding.wells.join(", ")}>{finding.wells.slice(0, 8).join(", ")}{finding.wells.length > 8 ? "…" : ""}</small> : null}</div></li>)}</ul> : null}
             </div>
           </aside>
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -359,20 +359,21 @@ main { padding-bottom: 40px; }
 .side-control-grid .field { grid-template-rows: auto var(--ln-control-height-sm) auto; gap: 5px; font-size: var(--ln-font-size-xs); }
 .side-control-grid .field input,.side-control-grid .field select { min-height: var(--ln-control-height-sm); padding: 7px 9px; font-size: var(--ln-font-size-sm); }
 .qc-compact-block { border-top: 1px solid var(--line); }
-.side-section-title { display: flex; align-items: center; justify-content: space-between; gap: var(--ln-space-3); padding: var(--ln-space-4) var(--ln-space-5) var(--ln-space-2); }
+.side-section-title { display: flex; align-items: center; justify-content: space-between; gap: var(--ln-space-3); padding: var(--ln-space-3) var(--ln-space-4); }
 .side-section-title strong { font-size: var(--ln-font-size-lg); }
 .side-section-title span { color: var(--muted); font-size: var(--ln-font-size-xs); font-weight: 800; }
-.qc-mini-list { max-height: 440px; overflow: auto; margin: 0; padding: 0; list-style: none; }
-.qc-mini-list li { display: grid; grid-template-columns: 42px minmax(0,1fr); gap: var(--ln-space-3); padding: var(--ln-space-3) var(--ln-space-4); border-top: 1px solid #eee7df; cursor: pointer; }
+.qc-compact-block.clear .side-section-title span { color: var(--success); }
+.qc-mini-list { max-height: 300px; overflow: auto; margin: 0; padding: 0; list-style: none; }
+.qc-mini-list li { display: grid; grid-template-columns: 36px minmax(0,1fr); gap: var(--ln-space-2); padding: var(--ln-space-1) var(--ln-space-3); border-top: 1px solid #eee7df; cursor: pointer; }
 .qc-mini-list li:hover { background: #fffaf3; }
-.qc-mini-list li span { height: fit-content; padding: var(--ln-space-1) 5px; border-radius: var(--ln-radius-pill); font-size: var(--ln-font-size-2xs); font-weight: 850; text-align: center; text-transform: uppercase; }
+.qc-mini-list li span { height: fit-content; padding: 3px 4px; border-radius: var(--ln-radius-pill); font-size: var(--ln-font-size-2xs); font-weight: 850; text-align: center; text-transform: uppercase; }
 .qc-mini-list li.error span { color: var(--danger); background: var(--danger-soft); }
 .qc-mini-list li.warning span { color: var(--warning); background: var(--warning-soft); }
 .qc-mini-list li.info span { color: #1d4c50; background: #e8f0ee; }
 .qc-mini-list li strong { font-size: var(--ln-font-size-xs); }
-.qc-mini-list li p { margin: 3px 0 0; color: var(--graphite); font-size: var(--ln-font-size-xs); line-height: 1.35; }
-.qc-mini-list li small { display: block; margin-top: 3px; color: var(--muted); font-size: var(--ln-font-size-2xs); }
-.empty-state.compact { min-height: 90px; font-size: var(--ln-font-size-sm); }
+.qc-mini-list li p { display: -webkit-box; overflow: hidden; margin: 2px 0 0; color: var(--graphite); font-size: var(--ln-font-size-xs); line-height: 1.35; -webkit-box-orient: vertical; -webkit-line-clamp: 2; }
+.qc-mini-list li small { display: block; overflow: hidden; margin-top: 2px; color: var(--muted); font-size: var(--ln-font-size-2xs); text-overflow: ellipsis; white-space: nowrap; }
+.empty-state.compact { min-height: 56px; font-size: var(--ln-font-size-sm); }
 .summary-panel-head { display: grid; grid-template-columns: minmax(0,1fr) auto; align-items: start; }
 .summary-panel-head > div:first-child { min-width: 0; }
 .summary-head-actions { display: flex; flex-wrap: nowrap; align-items: center; justify-content: flex-end; gap: var(--ln-space-2); max-width: none; }


### PR DESCRIPTION
Closes #31

## Changes
- Replace the zero-finding QC empty block with an inline `无需复核` status.
- Reduce QC header padding, finding-row spacing, severity-column width, and list maximum height.
- Clamp long finding messages to two lines and well references to one ellipsized line while keeping full values in the DOM and title text.
- Preserve severity, codes, messages, well references, and click-to-select behavior.
- Add browser guards for worst-case finding row height and QC list height.

## Verification
- `npm run typecheck`
- `npm run test:unit` (36 tests)
- `npm run build`
- `npm run test:browser`
- Impeccable detector: 0 findings