### PR TITLE
Make inferred assay methods reviewable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Microplate Assay Studio
 
-面向酶标仪/多功能微孔板读数仪的一体化分析工作台。当前版本为 v0.6.0，使用真实 Thermo Scientific Varioskan LUX / SkanIt XML、XLSX 和旧版 VICTOR XLS 数据开发。
+面向酶标仪/多功能微孔板读数仪的一体化分析工作台。当前版本为 v0.6.1，使用真实 Thermo Scientific Varioskan LUX / SkanIt XML、XLSX 和旧版 VICTOR XLS 数据开发。
 
 ## 工具定位
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "microplate-assay-studio",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "microplate-assay-studio",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "dependencies": {
         "react": "19.2.6",
         "react-dom": "19.2.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "microplate-assay-studio",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "type": "module",
   "engines": {

--- a/scripts/visual-smoke.mjs
+++ b/scripts/visual-smoke.mjs
@@ -48,7 +48,7 @@ function normalizationPlate(name, timepoint, blank, values) {
 const normalizationProjectPath = resolve(screenshotDir, "browser-baseline-normalization-project.json");
 await writeFile(normalizationProjectPath, JSON.stringify({
   schemaVersion: 3,
-  tool: { id: "microplate-assay-studio", version: "0.6.0" },
+  tool: { id: "microplate-assay-studio", version: "0.6.1" },
   generatedAt: new Date(0).toISOString(),
   experiment: { name: "Browser baseline normalization", operator: "", date: "", notes: "" },
   activeModuleId: "cell-viability",
@@ -102,11 +102,7 @@ try {
     throw new Error(`Global content frames are not aligned: left ${frameLefts.join(", ")}; right ${frameRights.join(", ")}.`);
   }
   if (!headerFrame || !assayFrame || !workspaceFrame) throw new Error("Unable to verify global content frame alignment.");
-  const workflowSummaryPadding = await workflowDisclosure.locator("summary").evaluate((element) => getComputedStyle(element).paddingLeft);
-  const experimentSummaryPadding = await page.locator(".experiment-record summary").evaluate((element) => getComputedStyle(element).paddingLeft);
-  if (workflowSummaryPadding !== experimentSummaryPadding) {
-    throw new Error(`Import disclosures do not share one text rail: ${workflowSummaryPadding} vs ${experimentSummaryPadding}.`);
-  }
+  if (await page.getByText("实验记录信息", { exact: true }).count()) throw new Error("Removed experiment-record strip returned to the import workspace.");
   await page.screenshot({ path: resolve(screenshotDir, "microplate-studio-global-frame-wide.png"), fullPage: true });
   await page.setViewportSize({ width: 320, height: 800 });
   const mobileImportOverflow = await page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth);
@@ -320,6 +316,17 @@ try {
     const importedText = await page.locator("body").innerText();
     requiredImportSignals = ["本次实验基本信息", "CCK-8 / WST-8", "吸光", "450 nm", "96 个已测孔"];
     assertSignals(importedText, requiredImportSignals, "Instrument import");
+    const reviewButton = page.getByRole("button", { name: "核对实验方法" });
+    if (!await reviewButton.isVisible()) throw new Error("Inferred assay method does not expose a review action.");
+    await reviewButton.click();
+    const methodReview = page.getByLabel("实验方法复核");
+    await methodReview.getByLabel("确认方法").fill("CCK-8 / WST-8 · 人工确认");
+    await methodReview.getByRole("button", { name: "确认方法" }).click();
+    if (!await page.getByRole("button", { name: "已复核 · 修改" }).isVisible()) throw new Error("Assay method review did not reach a confirmed state.");
+    const reviewedOverview = await page.locator(".experiment-overview").innerText();
+    for (const signal of ["CCK-8 / WST-8 · 人工确认", "原始识别：CCK-8 / WST-8"]) {
+      if (!reviewedOverview.includes(signal)) throw new Error(`Reviewed assay provenance is missing: ${signal}`);
+    }
     await page.screenshot({ path: resolve(screenshotDir, "microplate-studio-imported.png"), fullPage: true });
     await page.getByRole("button", { name: "进入板图与注释" }).click();
     const layoutText = await page.locator("body").innerText();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -79,7 +79,14 @@ function detectionModeLabel(mode: DetectionMode): string {
 }
 
 function methodEvidenceLabel(plate: ParsedPlate): string {
+  if (plate.metadata.assayMethodReviewDecision === "user-confirmed") {
+    return `人工复核确认 · 原始识别：${plate.metadata.assayMethodLabel || "未提供"}`;
+  }
   return ({ reported: "仪器协议明确记录", "user-reported": "由用户在导入时填写", inferred: "根据通道与当前流程推断，请复核", unknown: "文件未提供" })[plate.metadata.assayMethodEvidence];
+}
+
+function displayedAssayMethodLabel(plate: ParsedPlate): string {
+  return plate.metadata.confirmedAssayMethodLabel ?? plate.metadata.assayMethodLabel;
 }
 
 function measurementChannel(plate: ParsedPlate): string {
@@ -191,6 +198,8 @@ export default function App() {
   const [loading, setLoading] = useState(false);
   const [notice, setNotice] = useState("");
   const [error, setError] = useState("");
+  const [methodReviewOpen, setMethodReviewOpen] = useState(false);
+  const [methodReviewDraft, setMethodReviewDraft] = useState("");
   const selectedModule = assayModules.find((module) => module.id === selectedModuleId) ?? assayModules[0];
   const workspaceView = useMemo(() => workspace ? readPlateWorkspace(workspace) : null, [workspace]);
   const plates = useMemo(() => workspace ? workspacePlates(workspace) : [], [workspace]);
@@ -207,6 +216,9 @@ export default function App() {
   const plateZoom = platePresentation.zoom;
   const activeModuleId = workspaceView?.activeModuleId ?? selectedModuleId;
   const activeModule = workspaceView?.activeModule ?? getAssayWorkflow(activeModuleId);
+  const assayMethodNeedsReview = Boolean(plate
+    && plate.metadata.assayMethodReviewDecision !== "user-confirmed"
+    && (plate.metadata.assayMethodEvidence === "inferred" || plate.metadata.assayMethodEvidence === "unknown"));
   const groups = workspaceView?.groups ?? [];
   const inferredControlGroup = workspaceView?.inferredControlGroup ?? "";
   const analysis = workspaceView?.analysis ?? { ready: false, blankMean: null, blankSd: null, blankCvPercent: null, annotatedWells: [], technicalSummaries: [], biologicalSummaries: [], significanceComparisons: [], findings: [] };
@@ -320,6 +332,7 @@ export default function App() {
       const confirmed = window.confirm(`将当前板从“${activeModule.name}”切换为“${nextModule.name}”。\n\n原始读数和通用孔位注释会保留；旧模块的派生结果将不再作为当前结果展示。是否继续？`);
       if (!confirmed) return;
       setWorkspace((current) => current ? transitionPlateWorkspace(current, { type: "assign-active-assay", moduleId }) : current);
+      setMethodReviewOpen(false);
     }
     setSelectedModuleId(moduleId);
     setModuleSelectionTouched(true);
@@ -353,6 +366,7 @@ export default function App() {
     });
     const nextPlates = workspacePlates(nextWorkspace);
     setWorkspace(nextWorkspace);
+    setMethodReviewOpen(false);
     setPlatePresentations(nextPlates.map(() => ({ zoom: 1, zoomManuallyChanged: false })));
     setPendingBatch(null);
     setPendingIncludedPlates(new Set());
@@ -382,6 +396,7 @@ export default function App() {
     clearBatchDraft();
     const nextWorkspace = transitionPlateWorkspace(workspace, { type: "select-plate", index });
     setWorkspace(nextWorkspace);
+    setMethodReviewOpen(false);
     resetPlatePresentation(next);
     setSelectedModuleId(nextWorkspace.selectedModuleId);
     setModuleSelectionTouched(false);
@@ -390,6 +405,24 @@ export default function App() {
 
   function renameActivePlate(name: string) {
     setWorkspace((current) => current ? transitionPlateWorkspace(current, { type: "rename-active-plate", name }) : current);
+  }
+
+  function openMethodReview() {
+    if (!plate) return;
+    setMethodReviewDraft(displayedAssayMethodLabel(plate));
+    setMethodReviewOpen(true);
+  }
+
+  function confirmMethodReview() {
+    const label = methodReviewDraft.trim();
+    if (!label) {
+      setError("请先填写或选择实验方法，再完成复核。");
+      return;
+    }
+    setWorkspace((current) => current ? transitionPlateWorkspace(current, { type: "review-active-assay-method", label }) : current);
+    setMethodReviewOpen(false);
+    setError("");
+    setNotice(`实验方法已人工复核为“${label}”；仪器记录和系统原始识别保持不变。`);
   }
 
   async function importInstrumentFile(file: File) {
@@ -570,11 +603,6 @@ export default function App() {
     downloadArtifact(createArtifact({ kind: artifactKind, plate, result: displayedAnalysis, scope: exportScope, analysisConfig: config }));
   }
 
-  function updateExperiment(patch: Partial<typeof experiment>) {
-    if (!workspace) return;
-    setWorkspace(transitionPlateWorkspace(workspace, { type: "set-experiment", experiment: { ...experiment, ...patch } }));
-  }
-
   function updateAnalysisConfig(patch: Partial<typeof config>, touched = controlGroupTouched) {
     if (!workspace) return;
     setWorkspace(transitionPlateWorkspace(workspace, { type: "set-analysis-config", config: { ...config, ...patch }, touched }));
@@ -681,23 +709,18 @@ export default function App() {
         </div> : null}
 
         <AssayWorkflowPanel variant="disclosure" module={selectedModule} plate={plate && activeModuleId === selectedModuleId ? plate : null} />
-        <details className="experiment-record" open={Boolean(experiment.name || experiment.operator || experiment.date || experiment.notes)}>
-          <summary>实验记录信息 <small>随可复现项目和溯源导出保存</small></summary>
-          <div className="experiment-record-grid">
-            <Field label="实验名称"><input value={experiment.name} onChange={(event) => updateExperiment({ name: event.target.value })} placeholder="例如 Drug response · Day 2" /></Field>
-            <Field label="操作者"><input value={experiment.operator} onChange={(event) => updateExperiment({ operator: event.target.value })} /></Field>
-            <Field label="实验日期"><input type="date" value={experiment.date} onChange={(event) => updateExperiment({ date: event.target.value })} /></Field>
-            <Field label="项目备注"><input value={experiment.notes} onChange={(event) => updateExperiment({ notes: event.target.value })} /></Field>
-          </div>
-        </details>
-
         {plates.length > 1 ? <div className="plate-switcher"><div><strong>本次导入包含 {plates.length} 块板</strong><small>各板注释与分析相互独立，不会自动合并为生物学重复。</small></div><div className="plate-switcher-buttons">{plates.map((item, index) => <button type="button" key={`${item.metadata.plateName}-${index}`} className={index === activePlateIndex ? "active" : ""} onClick={() => selectActivePlate(index)}>{index + 1}. {item.metadata.plateName}</button>)}</div><label>当前板名称<input value={plate?.metadata.plateName ?? ""} onChange={(event) => renameActivePlate(event.target.value)} /></label></div> : null}
         {plate ? <div className="experiment-overview">
-          <div className="experiment-overview-head"><div><h3>本次实验基本信息</h3><p>仪器报告值、用户填写值和推断项会分别标明；人工读数不会伪装成仪器元数据。</p></div><span className={`evidence-badge ${plate.metadata.assayMethodEvidence}`}>{plate.metadata.assayMethodEvidence === "reported" ? "协议已记录" : plate.metadata.assayMethodEvidence === "user-reported" ? "用户已填写" : "需复核"}</span></div>
+          <div className="experiment-overview-head"><div><h3>本次实验基本信息</h3><p>仪器报告值、用户填写值和推断项分别保留；人工确认不会覆盖原始记录。</p></div>{plate.metadata.assayMethodReviewDecision === "user-confirmed" ? <button type="button" className="evidence-badge user-reviewed" onClick={openMethodReview}>已复核 · 修改</button> : plate.metadata.assayMethodEvidence === "reported" ? <span className="evidence-badge reported">协议已记录</span> : plate.metadata.assayMethodEvidence === "user-reported" ? <span className="evidence-badge user-reported">用户已填写</span> : assayMethodNeedsReview ? <button type="button" className={`evidence-badge review-action ${plate.metadata.assayMethodEvidence}`} onClick={openMethodReview}>核对实验方法</button> : null}</div>
+          {methodReviewOpen ? <div className="method-review-panel" aria-label="实验方法复核">
+            <div><strong>核对实验方法</strong><p>确认值用于后续展示与导出；仪器记录和系统原始识别不会被改写。</p></div>
+            <label>确认方法<input list="assay-method-options" value={methodReviewDraft} onChange={(event) => setMethodReviewDraft(event.target.value)} autoFocus /><datalist id="assay-method-options">{activeModule.supportedMethods.map((method) => <option key={method} value={method} />)}</datalist></label>
+            <div className="method-review-actions"><button type="button" className="secondary-button mini" onClick={() => setMethodReviewOpen(false)}>取消</button><button type="button" className="primary-button mini" onClick={confirmMethodReview}>确认方法</button></div>
+          </div> : null}
           <div className="metadata-grid experiment-metadata-grid">
             <Metric label="确认实验类型" value={activeModule.name} detail={`决策：${plate.metadata.assayAssignmentDecision ?? "未记录"}`} />
             <Metric label="系统识别类型" value={detectedAssayModule(plate) === "unknown" ? "未可靠识别" : getAssayWorkflow(detectedAssayModule(plate)).name} detail="与用户确认结果分别保留" />
-            <Metric label="实验方法" value={plate.metadata.assayMethodLabel} detail={methodEvidenceLabel(plate)} />
+            <Metric label="实验方法" value={displayedAssayMethodLabel(plate)} detail={methodEvidenceLabel(plate)} />
             <Metric label="检测模式" value={detectionModeLabel(plate.metadata.detectionMode)} detail={`${plate.metadata.measurementName || "未命名通道"} · ${plate.metadata.signalUnit || "无单位"}`} />
             <Metric label="读数通道" value={measurementChannel(plate)} detail={plate.metadata.detectionMode === "fluorescence" ? "激发 / 发射" : "主波长 / 参比波长"} />
             <Metric label="仪器" value={instrumentDisplay(plate)} detail={plate.metadata.instrumentSerialNumber ? `S/N ${plate.metadata.instrumentSerialNumber}` : "序列号未记录"} />
@@ -708,7 +731,7 @@ export default function App() {
           </div>
         </div> : null}
         {plate?.warnings.length ? <ul className="compact-findings">{plate.warnings.map((warning) => <li key={warning}>{warning}</li>)}</ul> : null}
-        {plate ? <div className="next-step import-next-step"><div><strong>基本信息已解析</strong><p>{useGenericWorkflow ? `已保留 ${plate.assayData?.measurements.length ?? 0} 个测量/计算步骤；下一步可检查板图身份与孔位注释。` : "请复核实验方法和检测通道；下一步补充样本、对照、空白与重复信息。"}</p></div><button type="button" className="primary-button" onClick={() => navigateTo("layout")}>进入板图与注释</button></div> : null}
+        {plate ? <div className="next-step import-next-step"><div><strong>基本信息已解析</strong><p>{useGenericWorkflow ? `已保留 ${plate.assayData?.measurements.length ?? 0} 个测量/计算步骤；下一步可检查板图身份与孔位注释。` : assayMethodNeedsReview ? "请先核对实验方法；下一步补充样本、对照、空白与重复信息。" : "实验方法已有明确来源或已完成复核；下一步补充样本、对照、空白与重复信息。"}</p></div><button type="button" className="primary-button" onClick={() => navigateTo("layout")}>进入板图与注释</button></div> : null}
       </section> : null}
 
       {view === "layout" && plate ? <section className="workspace">

--- a/src/core/artifacts.ts
+++ b/src/core/artifacts.ts
@@ -229,7 +229,7 @@ export function createArtifact(request: ArtifactRequest): ReproducibleArtifact {
       filename: artifactName(request.plate.metadata.sourceFileName, "analysis-package.json"),
       mimeType: "application/json",
       content: JSON.stringify({
-        schemaVersion: 1, tool: toolIdentity, assay: { id: "cell-viability", label: request.plate.metadata.assayMethodLabel },
+        schemaVersion: 1, tool: toolIdentity, assay: { id: "cell-viability", label: request.plate.metadata.confirmedAssayMethodLabel ?? request.plate.metadata.assayMethodLabel },
         generatedAt: new Date().toISOString(), source: request.plate.metadata, config: request.analysisConfig,
         annotations: request.wells.map(({ rawValue: _rawValue, ...well }) => well),
         projectSources: request.plates.map((plate) => ({

--- a/src/core/assay-workflows.ts
+++ b/src/core/assay-workflows.ts
@@ -146,6 +146,15 @@ export function assignmentDecision(
 
 export type WorkflowFact = { label: string; value: string; evidence: "instrument" | "user" | "missing" };
 
+function reviewedMethodLabel(plate: ParsedPlate): string {
+  return plate.metadata.confirmedAssayMethodLabel ?? plate.metadata.assayMethodLabel;
+}
+
+function methodEvidence(plate: ParsedPlate): WorkflowFact["evidence"] {
+  if (plate.metadata.assayMethodReviewDecision === "user-confirmed" || plate.metadata.assayMethodEvidence === "user-reported") return "user";
+  return plate.metadata.assayMethodEvidence === "unknown" ? "missing" : "instrument";
+}
+
 function countSeries(plate: ParsedPlate, predicate: (name: string) => boolean): number {
   return plate.assayData?.measurements.filter((series) => predicate(series.name)).length ?? 0;
 }
@@ -157,7 +166,7 @@ export function assayWorkflowFacts(plate: ParsedPlate, moduleId: AssayModuleId):
     const curves = dataset?.standardCurves.length ?? 0;
     const calculated = dataset?.measurements.filter((series) => series.source === "instrument-calculated").length ?? 0;
     return [
-      { label: "定量方法", value: plate.metadata.assayMethodLabel || "未确认", evidence: plate.metadata.assayMethodEvidence === "user-reported" ? "user" : "instrument" },
+      { label: "定量方法", value: reviewedMethodLabel(plate) || "未确认", evidence: methodEvidence(plate) },
       { label: "标准曲线", value: curves ? `${curves} 条仪器曲线` : "未提供", evidence: curves ? "instrument" : "missing" },
       { label: "仪器计算步骤", value: calculated ? `${calculated} 个` : "未提供", evidence: calculated ? "instrument" : "missing" },
       missing("稀释倍数"),
@@ -185,7 +194,7 @@ export function assayWorkflowFacts(plate: ParsedPlate, moduleId: AssayModuleId):
     ];
   }
   return [
-    { label: "具体方法", value: plate.metadata.assayMethodLabel || "未确认", evidence: plate.metadata.assayMethodEvidence === "user-reported" ? "user" : plate.metadata.assayMethodEvidence === "unknown" ? "missing" : "instrument" },
+    { label: "具体方法", value: reviewedMethodLabel(plate) || "未确认", evidence: methodEvidence(plate) },
     { label: "检测模式", value: plate.metadata.detectionMode, evidence: plate.metadata.assayMethodEvidence === "user-reported" ? "user" : "instrument" },
     { label: "测量步骤", value: dataset?.measurements.length ? `${dataset.measurements.length} 个` : "单一原始读数", evidence: dataset ? "instrument" : "user" },
   ];

--- a/src/core/plate-aggregate.ts
+++ b/src/core/plate-aggregate.ts
@@ -117,6 +117,24 @@ export function assignPlateAssay(aggregate: PlateAggregate, moduleId: AssayModul
         selectedAssayModuleId: moduleId,
         confirmedAssayModuleId: moduleId,
         assayAssignmentDecision: "user-confirmed",
+        confirmedAssayMethodLabel: undefined,
+        assayMethodReviewDecision: undefined,
+      },
+    },
+  };
+}
+
+export function reviewPlateAssayMethod(aggregate: PlateAggregate, label: string): PlateAggregate {
+  const confirmedLabel = label.trim();
+  if (!confirmedLabel) throw new Error("确认实验方法前需要填写方法名称。");
+  return {
+    ...aggregate,
+    source: {
+      ...aggregate.source,
+      metadata: {
+        ...aggregate.source.metadata,
+        confirmedAssayMethodLabel: confirmedLabel,
+        assayMethodReviewDecision: "user-confirmed",
       },
     },
   };

--- a/src/core/plate-workspace.ts
+++ b/src/core/plate-workspace.ts
@@ -8,6 +8,7 @@ import {
   createPlateAggregate,
   renamePlate,
   replaceWellAnnotations,
+  reviewPlateAssayMethod,
   updateWellAnnotations,
   type PlateAggregate,
   type WellAnnotation,
@@ -56,6 +57,7 @@ export type PlateWorkspaceAction =
   | { type: "select-plate"; index: number }
   | { type: "rename-active-plate"; name: string }
   | { type: "assign-active-assay"; moduleId: AssayModuleId }
+  | { type: "review-active-assay-method"; label: string }
   | { type: "select-wells"; wellIds: ReadonlySet<string>; anchor: string | null }
   | { type: "replace-active-wells"; wells: WellRecord[] }
   | { type: "update-selected-annotations"; update: (annotation: WellAnnotation, well: WellRecord, index: number) => WellAnnotation }
@@ -216,6 +218,11 @@ export function transitionPlateWorkspace(workspace: PlateWorkspace, action: Plat
       selectedModuleId: action.moduleId,
       selectedSummaryKeys: new Set(),
       plates: workspace.plates.map((plate, index) => index === workspace.activePlateIndex ? assignPlateAssay(plate, action.moduleId) : plate),
+    };
+  } else if (action.type === "review-active-assay-method") {
+    next = {
+      ...workspace,
+      plates: workspace.plates.map((plate, index) => index === workspace.activePlateIndex ? reviewPlateAssayMethod(plate, action.label) : plate),
     };
   } else if (action.type === "select-wells") {
     next = { ...workspace, selectedWellIds: new Set(action.wellIds), selectionAnchor: action.anchor };

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -24,6 +24,7 @@ export type AssayModuleDefinition = {
 };
 
 export type AssayAssignmentDecision = "matched" | "system-detected" | "user-confirmed" | "manual" | "project-restored";
+export type AssayMethodReviewDecision = "user-confirmed";
 
 export type PlateMetadata = {
   sourceKind: PlateImportSource;
@@ -33,6 +34,8 @@ export type PlateMetadata = {
   assayMethod: CellViabilityMethod;
   assayMethodLabel: string;
   assayMethodEvidence: MetadataEvidence;
+  confirmedAssayMethodLabel?: string;
+  assayMethodReviewDecision?: AssayMethodReviewDecision;
   detectionMode: DetectionMode;
   signalUnit: string;
   wavelengthNm: number | null;

--- a/src/styles.css
+++ b/src/styles.css
@@ -262,7 +262,6 @@ main { padding-bottom: 40px; }
 .compact-workflow .assay-workflow-facts { margin-top: var(--ln-space-4); border: 0; border-top: 1px solid var(--line); }
 .compact-workflow .assay-workflow-facts > div { padding: var(--ln-space-3) var(--ln-space-4) 0 0; border: 0; }
 .compact-workflow .annotation-guidance { margin-top: var(--ln-space-4); padding: var(--ln-space-3) 0 0; border-top: 1px solid var(--line); background: transparent; }
-.experiment-record { margin: 0 0 var(--ln-space-5); border: 1px solid var(--line); border-radius: var(--ln-radius-lg); background: white; }.experiment-record summary { display: flex; align-items: baseline; gap: var(--ln-space-3); padding: var(--ln-space-4) var(--ln-space-5); color: var(--graphite); font-size: var(--ln-font-size-lg); font-weight: 800; cursor: pointer; }.experiment-record summary small { color: var(--muted); font-weight: 500; }.experiment-record-grid { display: grid; grid-template-columns: repeat(4,minmax(0,1fr)); gap: var(--ln-space-4); padding: 0 var(--ln-space-5) var(--ln-space-5); }
 .import-source-tabs button { min-height: var(--ln-control-height); padding: var(--ln-space-3) var(--ln-space-5); border: 0; border-radius: var(--ln-radius-md); color: var(--muted); background: transparent; font-weight: 800; }
 .import-source-tabs button.active { color: white; background: var(--violet); box-shadow: 0 6px 15px rgba(29,76,80,.18); }
 .manual-import-panel { display: grid; gap: var(--ln-space-5); padding: var(--ln-space-6); border: 1px solid var(--line); border-radius: var(--ln-radius-xl); background: #fbfaf7; }
@@ -294,6 +293,16 @@ main { padding-bottom: 40px; }
 .evidence-badge.reported { color: var(--success); border: 1px solid #c2d9cd; background: var(--success-soft); }
 .evidence-badge.user-reported { color: #774f30; border: 1px solid #dfc0a6; background: #fff2e6; }
 .evidence-badge.inferred,.evidence-badge.unknown { color: var(--warning); border: 1px solid #ead1aa; background: var(--warning-soft); }
+.evidence-badge.user-reviewed { color: var(--success); border: 1px solid #c2d9cd; background: var(--success-soft); }
+.evidence-badge.review-action,.evidence-badge.user-reviewed { min-height: var(--ln-control-height-xs); cursor: pointer; }
+.evidence-badge.review-action:hover,.evidence-badge.user-reviewed:hover { border-color: currentColor; }
+.evidence-badge.review-action:focus-visible,.evidence-badge.user-reviewed:focus-visible { outline: 2px solid var(--violet); outline-offset: 2px; }
+.method-review-panel { display: grid; grid-template-columns: minmax(250px,1fr) minmax(260px,.8fr) auto; align-items: end; gap: var(--ln-space-5); padding: var(--ln-space-4) var(--ln-panel-head-padding-x); border-bottom: 1px solid var(--line); background: #fffaf3; }
+.method-review-panel strong { color: var(--ink); font-size: var(--ln-font-size-lg); }
+.method-review-panel p { margin: var(--ln-space-1) 0 0; color: var(--muted); font-size: var(--ln-annotation-copy-size); line-height: var(--ln-line-height-normal); }
+.method-review-panel label { display: grid; gap: var(--ln-space-2); color: var(--muted); font-size: var(--ln-font-size-sm); font-weight: 800; }
+.method-review-panel input { min-height: var(--ln-control-height-sm); padding: var(--ln-space-2) var(--ln-space-3); font-size: var(--ln-font-size-md); }
+.method-review-actions { display: flex; gap: var(--ln-space-2); }
 .metadata-grid,.metric-cards { display: grid; grid-template-columns: repeat(var(--ln-metadata-grid-columns),minmax(0,1fr)); gap: var(--ln-card-gap); margin-top: var(--ln-space-8); }
 .experiment-metadata-grid { margin-top: 0; padding: var(--ln-space-5); }
 .metric { min-width: 0; min-height: var(--ln-metadata-card-min-height); padding: var(--ln-space-5) var(--ln-space-6); border: 1px solid var(--line); border-radius: var(--ln-radius-lg); background: var(--ln-color-surface-warm); }.metric span,.metric strong,.metric small { display: block; }.metric span { color: var(--muted); font-size: var(--ln-font-size-xs); font-weight: 750; letter-spacing: .06em; text-transform: uppercase; }.metric strong { display: -webkit-box; overflow: hidden; margin-top: var(--ln-space-2); font-size: var(--ln-font-size-xl); line-height: var(--ln-line-height-tight); overflow-wrap: anywhere; -webkit-box-orient: vertical; -webkit-line-clamp: 2; }.metric small { display: -webkit-box; overflow: hidden; margin-top: var(--ln-space-2); color: var(--muted); font-size: var(--ln-annotation-copy-size); line-height: var(--ln-line-height-normal); -webkit-box-orient: vertical; -webkit-line-clamp: 2; }
@@ -458,7 +467,9 @@ main { padding-bottom: 40px; }
   .summary-panel-head { align-items: flex-start; flex-direction: column; }
   .summary-head-actions { justify-content: flex-start; max-width: none; }
   .assay-result-grid,.assay-step-controls { grid-template-columns: 1fr; }
-  .assay-workflow-header { flex-direction: column; }.mode-pills { justify-content: flex-start; }.assay-workflow-columns,.assay-workflow-facts,.experiment-record-grid { grid-template-columns: 1fr 1fr; }.assay-workflow-columns > div:nth-child(2),.assay-workflow-facts > div:nth-child(2) { border-right: 0; }
+  .assay-workflow-header { flex-direction: column; }.mode-pills { justify-content: flex-start; }.assay-workflow-columns,.assay-workflow-facts { grid-template-columns: 1fr 1fr; }.assay-workflow-columns > div:nth-child(2),.assay-workflow-facts > div:nth-child(2) { border-right: 0; }
+  .method-review-panel { grid-template-columns: 1fr; align-items: stretch; }
+  .method-review-actions { justify-content: flex-end; }
 }
 
 /* Readability pass: component groups point back to tokenized UI density. */

--- a/tests/plate-workspace.test.ts
+++ b/tests/plate-workspace.test.ts
@@ -46,6 +46,31 @@ describe("Plate workspace acceptance scenarios", () => {
     expect(aggregatePlate(aggregate).wells[2].rawValue).toBe(0.5);
   });
 
+  it("stores a reviewed assay method separately from source inference", () => {
+    const inferredPlate = fixturePlate();
+    inferredPlate.metadata = { ...inferredPlate.metadata, assayMethodEvidence: "inferred" };
+    let workspace = openPlateWorkspace(planWorkspaceImport(fixtureBatch([inferredPlate]), "cell-viability", false));
+    const before = readPlateWorkspace(workspace).activePlate;
+    const rawValues = before.wells.map((well) => well.rawValue);
+    workspace = transitionPlateWorkspace(workspace, { type: "review-active-assay-method", label: "  CCK-8 / WST-8  " });
+    const reviewed = readPlateWorkspace(workspace).activePlate;
+
+    expect(reviewed.metadata.confirmedAssayMethodLabel).toBe("CCK-8 / WST-8");
+    expect(reviewed.metadata.assayMethodReviewDecision).toBe("user-confirmed");
+    expect(reviewed.metadata.assayMethodLabel).toBe(before.metadata.assayMethodLabel);
+    expect(reviewed.wells.map((well) => well.rawValue)).toEqual(rawValues);
+
+    workspace = transitionPlateWorkspace(workspace, { type: "assign-active-assay", moduleId: "protein-quant" });
+    const reassigned = readPlateWorkspace(workspace).activePlate;
+    expect(reassigned.metadata.confirmedAssayMethodLabel).toBeUndefined();
+    expect(reassigned.metadata.assayMethodReviewDecision).toBeUndefined();
+  });
+
+  it("rejects an empty method review instead of creating a meaningless confirmed state", () => {
+    const workspace = openPlateWorkspace(planWorkspaceImport(fixtureBatch(), "cell-viability", false));
+    expect(() => transitionPlateWorkspace(workspace, { type: "review-active-assay-method", label: "   " })).toThrow(/填写方法名称/);
+  });
+
   it("produces project-ready plates without exposing duplicate annotation state", () => {
     let workspace = openPlateWorkspace(planWorkspaceImport(fixtureBatch(), "cell-viability", true));
     workspace = transitionPlateWorkspace(workspace, { type: "rename-active-plate", name: "Day 1" });

--- a/tests/project-file.test.ts
+++ b/tests/project-file.test.ts
@@ -23,7 +23,7 @@ describe("versioned reproducible artifact module", () => {
       notes: "confirmed",
     } : well);
     const experiment = { name: "Round trip", operator: "Researcher", date: "2026-08-22", notes: "local only" };
-    const artifact = createArtifact({ kind: "project", plates: [{ ...plate, wells }], experiment, activeModuleId: "cell-viability", analysisConfig: config });
+    const artifact = createArtifact({ kind: "project", plates: [{ ...plate, metadata: { ...plate.metadata, confirmedAssayMethodLabel: "CCK-8 / WST-8", assayMethodReviewDecision: "user-confirmed" }, wells }], experiment, activeModuleId: "cell-viability", analysisConfig: config });
     const restored = parseProjectArtifact(artifact.content, "round-trip.json");
 
     expect(artifact.filename).toContain("reproducible-project.json");
@@ -34,7 +34,7 @@ describe("versioned reproducible artifact module", () => {
     expect(restored.restoredAnalysisConfig?.baselineNormalization?.enabled).toBe(false);
     expect(restored.restoredActiveModuleId).toBe("cell-viability");
     expect(restored.plates[0].wells[0]).toMatchObject({ rawValue: 0, role: "control", group: "Control", notes: "confirmed" });
-    expect(restored.plates[0].metadata).toMatchObject({ reopenedFromProjectFile: "round-trip.json", assayAssignmentDecision: "project-restored" });
+    expect(restored.plates[0].metadata).toMatchObject({ reopenedFromProjectFile: "round-trip.json", assayAssignmentDecision: "project-restored", confirmedAssayMethodLabel: "CCK-8 / WST-8", assayMethodReviewDecision: "user-confirmed" });
   });
 
   it("rejects unrelated or unsupported JSON instead of guessing", () => {


### PR DESCRIPTION
Closes #37

## What changed
- removes the redundant experiment-record strip while preserving legacy project metadata
- adds a compact assay-method review action for inferred/unknown methods
- stores the human-confirmed label separately from instrument/system source metadata
- keeps the confirmed method in project and analysis-package exports
- clears stale method confirmation when the assay module changes
- bumps the standalone app to v0.6.1

## Verification
- `npm test` — 48 passed, 6 skipped
- real Varioskan LUX CCK-8 browser acceptance — passed, no console errors
- `npm run build:sites` — passed
- `npm run test:offline` — passed
- Impeccable detector — no findings