### PR TITLE
Consolidate result exports into a multi-sheet workbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Microplate Assay Studio
 
-面向酶标仪/多功能微孔板读数仪的一体化分析工作台。当前版本为 v0.6.2，使用真实 Thermo Scientific Varioskan LUX / SkanIt XML、XLSX 和旧版 VICTOR XLS 数据开发。
+面向酶标仪/多功能微孔板读数仪的一体化分析工作台。当前版本为 v0.6.3，使用真实 Thermo Scientific Varioskan LUX / SkanIt XML、XLSX 和旧版 VICTOR XLS 数据开发。
 
 ## 工具定位
 
@@ -21,7 +21,7 @@
 6. 支持 CCK-8/MTT/Resazurin/alamarBlue、BSA 蛋白定量与光谱、ATP 发光定量和 Dual-Luciferase demo 流程。
 7. 对 CCK-8 类组间实验，区分技术复孔与生物学重复，完成空白扣除、QC、对照归一化及显著性分析；同一块板允许存在多个独立的生物学重复，但技术复孔仍先在各自生物学重复内汇总。
 8. 对 ATP、BSA、alamarBlue 标准曲线和 Dual-Luciferase，逐步展示 SkanIt 原始测量与仪器计算结果，不擅自替换仪器算法。
-9. 导出包含当前孔注释、模块确认、选择决策、来源适配器、测量步骤和全部数据点的 tidy long-table CSV；CCK-8 流程另可导出孔级、技术复孔和生物学汇总结果。汇总 CSV 只保留明确命名的 `blank_corrected_*` 基础列和 `relative_to_control_*` 派生列，不设置重复的通用 `value / sd / sem` 别名。
+9. 导出包含当前孔注释、模块确认、选择决策、来源适配器、测量步骤和全部数据点的 tidy long-table CSV；细胞活性/增殖流程可导出结果 Excel，其中整合导出说明、生物学汇总、孔级数据和可读板布局。技术复孔仍作为统计计算的内部中间层，但不再提供单独下载文件。汇总 CSV 只保留明确命名的 `blank_corrected_*` 基础列和 `relative_to_control_*` 派生列，不设置重复的通用 `value / sd / sem` 别名。
 10. 可保存并重新打开浏览器本地的可复现项目文件，恢复原始读值、当前注释、实验基本信息、模块识别/确认和分析配置。
 11. 无仪器原始文件时，可直接粘贴 Excel 中的固定孔板矩阵，或下载并填写 6/12/24/48/96/384 孔读数模板后导入。
 12. 同一次粘贴或模板导入可识别多块板；每块板保留独立名称、注释和分析状态，不会自动合并为生物学重复。
@@ -75,6 +75,7 @@ npm test
 - 板图框选、追加选择、逐孔取消、缩放、批量草稿保留与离开保护。
 - 当前板布局导出、CSV 引号回读、跨板型预警、生物学重复清空选项及原始读数只读保护。
 - CCK-8 的空白扣除、技术复孔合并、生物学汇总，以及未归一化主值与相对 Control 派生列的导出边界。
+- 结果 Excel 的导出说明、生物学汇总、孔级数据和板布局工作表，以及点选范围、来源字段与下载回读。
 - 跨时间点 baseline normalization 的逐板 blank correction、精确 baseline 选择、Bio 匹配/回退规则、误差传播、异常基线门控、CSV 导出和项目文件往返恢复。
 - 同一块板多个生物学重复的统计层级，以及疑似把技术复孔误填为生物学重复时的提示。
 - 模块能力状态、识别/确认决策、带来源信息的 CSV 导出和可复现项目文件往返恢复。
@@ -113,6 +114,7 @@ npm run test:unit
 - `src/core/import.ts`：统一导入 interface；浏览器 `File` 与测试内存文件都通过相同 seam。
 - `src/core/instruments/registry.ts`：厂商格式 adapters、格式探测和结构化诊断。
 - `src/core/artifacts.ts`：版本化 project、分析包及 CSV artifact 的单一 schema/version 来源。
+- `src/core/result-workbook.ts`：结果 Excel 的工作表 schema、板布局矩阵和可读格式。
 - `src/adapters/browser-download.ts`：浏览器下载副作用，不包含科研计算。
 - `scripts/acceptance-harness.mjs`：在线与离线页面测试共用的浏览器 adapter、fixture 和断言工具。
 - `CONTEXT.md`：领域词汇；`docs/adr/`：需要长期保留的架构决策。

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "microplate-assay-studio",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "microplate-assay-studio",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "dependencies": {
         "react": "19.2.6",
         "react-dom": "19.2.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "microplate-assay-studio",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "private": true,
   "type": "module",
   "engines": {

--- a/scripts/visual-smoke.mjs
+++ b/scripts/visual-smoke.mjs
@@ -1,5 +1,6 @@
 import { resolve } from "node:path";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
+import XLSX from "xlsx-js-style";
 import { assertSignals, dragBetweenWells, manualPlateMatrix, openAcceptanceBrowser } from "./acceptance-harness.mjs";
 
 const screenshotDir = process.argv[2];
@@ -48,7 +49,7 @@ function normalizationPlate(name, timepoint, blank, values) {
 const normalizationProjectPath = resolve(screenshotDir, "browser-baseline-normalization-project.json");
 await writeFile(normalizationProjectPath, JSON.stringify({
   schemaVersion: 3,
-  tool: { id: "microplate-assay-studio", version: "0.6.2" },
+  tool: { id: "microplate-assay-studio", version: "0.6.3" },
   generatedAt: new Date(0).toISOString(),
   experiment: { name: "Browser baseline normalization", operator: "", date: "", notes: "" },
   activeModuleId: "cell-viability",
@@ -227,7 +228,8 @@ try {
   await page.getByRole("button", { name: /分析与导出/ }).click();
   const manualAnalysisText = await page.locator("body").innerText();
   if (!manualAnalysisText.includes("ROLE_UNASSIGNED")) throw new Error("Manual-paste analysis did not preserve the unassigned-well QC gate.");
-  if (!manualAnalysisText.includes("只保留语义明确的 blank_corrected_* 基础列")) throw new Error("Analysis UI did not explain the explicit export schema.");
+  if (!manualAnalysisText.includes("结果 Excel 同时包含生物学汇总、孔级数据和板布局")) throw new Error("Analysis UI did not explain the consolidated result workbook.");
+  if (await page.getByRole("button", { name: "技术复孔 CSV" }).count()) throw new Error("Standalone technical-replicate CSV action is still visible.");
   const qcFindingRows = await page.locator(".qc-mini-list li").all();
   const qcFindingHeights = await Promise.all(qcFindingRows.map(async (row) => (await row.boundingBox())?.height ?? Number.NaN));
   if (qcFindingHeights.some((height) => height > 84)) throw new Error(`QC findings are no longer compact: ${qcFindingHeights.join(", ")}.`);
@@ -405,6 +407,17 @@ try {
   await page.getByText("Calculated in Studio · baseline normalization", { exact: true }).waitFor();
   const normalizationStatusText = await normalizationDisclosure.innerText();
   if (!normalizationStatusText.toLowerCase().includes("ready")) throw new Error(`Baseline normalization did not reach ready state in the browser.\n${normalizationStatusText}`);
+  const workbookDownloadEvent = page.waitForEvent("download");
+  await page.getByRole("button", { name: "结果 Excel" }).click();
+  const workbookDownload = await workbookDownloadEvent;
+  const workbookPath = await workbookDownload.path();
+  if (!workbookPath || !workbookDownload.suggestedFilename().endsWith("-results-all.xlsx")) throw new Error("Consolidated result workbook was not downloaded.");
+  const workbook = XLSX.read(await readFile(workbookPath), { type: "buffer" });
+  const expectedWorkbookSheets = ["导出说明", "生物学汇总", "孔级数据", "板布局"];
+  if (JSON.stringify(workbook.SheetNames) !== JSON.stringify(expectedWorkbookSheets)) throw new Error(`Unexpected result workbook sheets: ${workbook.SheetNames.join(", ")}`);
+  const workbookSummaryRows = XLSX.utils.sheet_to_json(workbook.Sheets["生物学汇总"]);
+  const workbookWellRows = XLSX.utils.sheet_to_json(workbook.Sheets["孔级数据"]);
+  if (!workbookSummaryRows.length || !workbookWellRows.length) throw new Error("Result workbook sheets are empty.");
   const normalizedDownloadEvent = page.waitForEvent("download");
   await page.getByRole("button", { name: "标准化结果" }).click();
   const normalizedDownload = await normalizedDownloadEvent;
@@ -433,6 +446,7 @@ try {
     incompleteLayoutGateVisible,
     manualUnassignedGateVisible: manualAnalysisText.includes("ROLE_UNASSIGNED"),
     baselineNormalizationRoundTrip: true,
+    consolidatedWorkbookValidated: true,
     multiFileAppendValidated,
     genericLuxSignals,
     optionalVendorScenarios: { cck8: Boolean(process.env.CCK8_XLS), dualLuciferase: Boolean(process.env.DUAL_LUC_XLS), victor: Boolean(process.env.VICTOR_XLS) },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { defaultBaselineNormalizationConfig } from "./core/baseline-normalizatio
 import { importInstrumentFiles, importPlateReadings } from "./core/import";
 import { createReadingTemplateWorkbook, type ManualReadingMetadata } from "./core/instruments/manual-readings";
 import { currentPlateLayoutCsv, layoutTemplateCsv, plateTemplateDefinitions, previewLayoutText, type LayoutPatch } from "./core/layout";
+import { createResultWorkbook } from "./core/result-workbook";
 import {
   defaultAnalysisConfig,
   appendPlateWorkspace,
@@ -291,7 +292,6 @@ export default function App() {
   const displayedBiologicalSummaries = workspaceView?.displayedBiologicalSummaries ?? [];
   const displayedSignificanceComparisons = workspaceView?.displayedSignificanceComparisons ?? [];
   const displayedAnnotatedWells = displayedAnalysis.annotatedWells;
-  const displayedTechnicalSummaries = displayedAnalysis.technicalSummaries;
   const exportScope = workspaceView?.exportScope ?? "all";
   const layoutImportPreview = useMemo(() => plate && pendingLayoutFile
     ? previewLayoutText(wells, pendingLayoutFile.text, {
@@ -603,7 +603,7 @@ export default function App() {
     setNotice("当前板布局已导出；文件仅包含孔位注释，不包含原始读数和分析结果。");
   }
 
-  function exportFiles(kind: "wells" | "technical" | "biological" | "package" | "normalization-ready" | "normalized") {
+  function exportFiles(kind: "wells" | "workbook" | "biological" | "package" | "normalization-ready" | "normalized") {
     if (!plate) return;
     if (kind === "package") {
       downloadArtifact(createArtifact({ kind: "analysis-package", plate, plates, wells, analysisConfig: config, result: analysis, normalizationResult: baselineNormalization }));
@@ -618,7 +618,13 @@ export default function App() {
       }));
       return;
     }
-    const artifactKind = kind === "wells" ? "annotated-wells" : kind === "technical" ? "technical-summary" : "biological-summary";
+    if (kind === "workbook") {
+      const workbook = createResultWorkbook({ plate, result: displayedAnalysis, analysisConfig: config, scope: exportScope });
+      downloadBlob(workbook.filename, new Blob([workbook.bytes], { type: workbook.mimeType }));
+      setNotice("结果 Excel 已导出：包含导出说明、生物学汇总、孔级数据和板布局；技术复孔仍用于计算但不单独成表。");
+      return;
+    }
+    const artifactKind = kind === "wells" ? "annotated-wells" : "biological-summary";
     downloadArtifact(createArtifact({ kind: artifactKind, plate, result: displayedAnalysis, scope: exportScope, analysisConfig: config }));
   }
 
@@ -852,7 +858,7 @@ export default function App() {
 
       {view === "analysis" && plate && !useGenericWorkflow ? <section className="workspace analysis-workspace">
         <div className="section-heading split compact-heading">
-          <div><h2>分析与导出</h2><p>先合并技术复孔，再以生物学重复为统计单位；点选汇总表行后，下方图表、显著性和导出 CSV 都只保留当前展示范围。</p></div>
+          <div><h2>分析与导出</h2><p>先合并技术复孔，再以生物学重复为统计单位；点选汇总表行后，下方图表、显著性和结果导出都只保留当前展示范围。</p></div>
           <div className="analysis-heading-actions"><span className={`readiness ${analysis.ready ? "ready" : "review"}`}>{analysis.ready ? "Ready for export" : "Review required"}</span><button type="button" className="secondary-button mini" onClick={downloadProjectFile}>保存可复现项目</button></div>
         </div>
         <div className="analysis-layout-compact">
@@ -899,11 +905,11 @@ export default function App() {
 
           <section className="panel table-panel summary-panel">
             <div className="panel-head summary-panel-head">
-              <div><h3>生物学汇总表</h3><p>{selectedSummaryKeys.size ? `当前展示 ${displayedBiologicalSummaries.length} 行；显著性按当前点选范围重新计算。` : "点击行后，下方图表、显著性和导出内容只显示所选行。"} 汇总 CSV 只保留语义明确的 blank_corrected_* 基础列；relative_to_control_* 仅表示相对 Control 的派生结果。</p></div>
+              <div><h3>生物学汇总表</h3><p>{selectedSummaryKeys.size ? `当前展示 ${displayedBiologicalSummaries.length} 行；显著性按当前点选范围重新计算。` : "点击行后，下方图表、显著性和导出内容只显示所选行。"} 结果 Excel 同时包含生物学汇总、孔级数据和板布局；relative_to_control_* 仅表示相对 Control 的派生结果。</p></div>
               <div className="summary-head-actions">
                 {selectedSummaryKeys.size ? <button type="button" className="secondary-button mini" onClick={() => setWorkspace((current) => current ? transitionPlateWorkspace(current, { type: "clear-summary-selection" }) : current)}>显示全部</button> : null}
+                <button type="button" className="primary-button mini" disabled={!displayedBiologicalSummaries.length} onClick={() => exportFiles("workbook")}>结果 Excel</button>
                 <button type="button" className="secondary-button mini" disabled={!displayedAnnotatedWells.length} onClick={() => exportFiles("wells")}>孔级 CSV</button>
-                <button type="button" className="secondary-button mini" disabled={!displayedTechnicalSummaries.length} onClick={() => exportFiles("technical")}>技术复孔 CSV</button>
                 <button type="button" className="secondary-button mini" disabled={!displayedBiologicalSummaries.length} onClick={() => exportFiles("biological")}>汇总 CSV</button>
                 <button type="button" className="secondary-button mini" title="始终导出完整项目范围及 QC 状态，确保后续时间点包含其 baseline 依赖。" disabled={!baselineNormalization.normalizationReadyRows.length} onClick={() => exportFiles("normalization-ready")}>标准化准备表</button>
                 <button type="button" className="secondary-button mini" disabled={displayedBaselineNormalization.status !== "ready" || !displayedBaselineNormalization.normalizedRows.length} onClick={() => exportFiles("normalized")}>标准化结果</button>

--- a/src/core/artifacts.ts
+++ b/src/core/artifacts.ts
@@ -44,7 +44,7 @@ function csvEscape(value: unknown): string {
   return /[",\n\r]/.test(stringValue) ? `"${stringValue.replaceAll('"', '""')}"` : stringValue;
 }
 
-function rowsToCsv(headers: string[], rows: Array<Record<string, unknown>>): string {
+export function rowsToCsv(headers: string[], rows: Array<Record<string, unknown>>): string {
   return [headers.join(","), ...rows.map((row) => headers.map((header) => csvEscape(row[header])).join(","))].join("\n");
 }
 
@@ -53,15 +53,21 @@ function artifactName(source: string, suffix: string): string {
   return `${stem || "microplate"}-${suffix}`;
 }
 
-function annotatedWellsCsv(result: CellViabilityAnalysisResult, plate: ParsedPlate): string {
-  const headers = ["well", "row", "column", "instrument_label", "role", "sample_id", "group", "treatment", "concentration", "timepoint", "biological_replicate", "technical_replicate", "raw_signal", "blank_corrected_signal", "excluded", "notes", "plate_name", "import_source"];
-  return rowsToCsv(headers, result.annotatedWells.map((well) => ({
+export function annotatedWellExportRows(result: CellViabilityAnalysisResult, plate: ParsedPlate): Array<Record<string, unknown>> {
+  return result.annotatedWells.map((well) => ({
     well: well.well, row: well.row, column: well.column, instrument_label: well.instrumentLabel,
     role: well.role, sample_id: well.sampleId, group: well.group, treatment: well.treatment,
     concentration: well.concentration, timepoint: well.timepoint, biological_replicate: well.biologicalReplicate,
     technical_replicate: well.technicalReplicate, raw_signal: well.rawValue, blank_corrected_signal: well.blankCorrectedValue,
-    excluded: well.excluded, notes: well.notes, plate_name: plate.metadata.plateName, import_source: plate.metadata.sourceKind,
-  })));
+    excluded: well.excluded, notes: well.notes, plate_id: plate.plateId ?? "", plate_name: plate.metadata.plateName,
+    source_file: plate.metadata.sourceFileName, import_source: plate.metadata.sourceKind, adapter_id: plate.metadata.adapterId,
+    detection_mode: plate.metadata.detectionMode, signal_unit: plate.metadata.signalUnit,
+  }));
+}
+
+function annotatedWellsCsv(result: CellViabilityAnalysisResult, plate: ParsedPlate): string {
+  const headers = ["well", "row", "column", "instrument_label", "role", "sample_id", "group", "treatment", "concentration", "timepoint", "biological_replicate", "technical_replicate", "raw_signal", "blank_corrected_signal", "excluded", "notes", "plate_id", "plate_name", "source_file", "import_source", "adapter_id", "detection_mode", "signal_unit"];
+  return rowsToCsv(headers, annotatedWellExportRows(result, plate));
 }
 
 function technicalSummaryCsv(result: CellViabilityAnalysisResult, plate: ParsedPlate): string {
@@ -75,15 +81,9 @@ function technicalSummaryCsv(result: CellViabilityAnalysisResult, plate: ParsedP
   })));
 }
 
-function biologicalSummaryCsv(result: CellViabilityAnalysisResult, plate: ParsedPlate, analysisConfig?: AnalysisConfig): string {
+export function biologicalSummaryExportRows(result: CellViabilityAnalysisResult, plate: ParsedPlate, analysisConfig?: AnalysisConfig): Array<Record<string, unknown>> {
   const comparisonByGroup = new Map(result.significanceComparisons.map((comparison) => [[comparison.group, comparison.treatment, comparison.concentration, comparison.timepoint].join("¦"), comparison]));
-  const headers = [
-    "category", "group", "treatment", "concentration", "timepoint", "n_biological", "signal_basis",
-    "blank_corrected_mean", "blank_corrected_sd", "blank_corrected_sem",
-    "relative_to_control_percent", "relative_to_control_sd_percent", "relative_to_control_sem_percent", "normalization_reference", "normalization_method", "normalization_note",
-    "p_value_vs_control", "fdr_vs_control", "significance", "plate_name", "import_source",
-  ];
-  return rowsToCsv(headers, result.biologicalSummaries.map((row) => {
+  return result.biologicalSummaries.map((row) => {
     const comparison = comparisonByGroup.get([row.group, row.treatment, row.concentration, row.timepoint].join("¦"));
     return {
       category: [row.group, row.concentration, row.timepoint].filter(Boolean).join(" · "),
@@ -98,9 +98,20 @@ function biologicalSummaryCsv(result: CellViabilityAnalysisResult, plate: Parsed
       normalization_note: row.relativeActivityPercent === null ? "" : "Control mean is treated as an error-free fixed reference; denominator uncertainty is ignored.",
       p_value_vs_control: comparison?.pValue ?? "",
       fdr_vs_control: comparison?.adjustedPValue ?? "", significance: comparison?.label ?? "",
-      plate_name: plate.metadata.plateName, import_source: plate.metadata.sourceKind,
+      plate_id: plate.plateId ?? "", plate_name: plate.metadata.plateName, source_file: plate.metadata.sourceFileName,
+      import_source: plate.metadata.sourceKind, adapter_id: plate.metadata.adapterId,
     };
-  }));
+  });
+}
+
+function biologicalSummaryCsv(result: CellViabilityAnalysisResult, plate: ParsedPlate, analysisConfig?: AnalysisConfig): string {
+  const headers = [
+    "category", "group", "treatment", "concentration", "timepoint", "n_biological", "signal_basis",
+    "blank_corrected_mean", "blank_corrected_sd", "blank_corrected_sem",
+    "relative_to_control_percent", "relative_to_control_sd_percent", "relative_to_control_sem_percent", "normalization_reference", "normalization_method", "normalization_note",
+    "p_value_vs_control", "fdr_vs_control", "significance", "plate_id", "plate_name", "source_file", "import_source", "adapter_id",
+  ];
+  return rowsToCsv(headers, biologicalSummaryExportRows(result, plate, analysisConfig));
 }
 
 function normalizationReadyCsv(result: BaselineNormalizationResult): string {

--- a/src/core/result-workbook.ts
+++ b/src/core/result-workbook.ts
@@ -1,0 +1,144 @@
+import XLSX from "xlsx-js-style";
+import packageMetadata from "../../package.json";
+import { annotatedWellExportRows, biologicalSummaryExportRows } from "./artifacts";
+import type { AnalysisConfig, CellViabilityAnalysisResult, ParsedPlate, WellRole } from "./types";
+
+export type ResultWorkbook = {
+  filename: string;
+  mimeType: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+  bytes: ArrayBuffer;
+};
+
+type CellStyle = NonNullable<XLSX.CellObject["s"]>;
+
+const headerStyle: CellStyle = {
+  font: { bold: true, color: { rgb: "FFFFFF" } },
+  fill: { fgColor: { rgb: "285A59" } },
+  alignment: { vertical: "center", horizontal: "center", wrapText: true },
+  border: {
+    top: { style: "thin", color: { rgb: "D6E1DC" } },
+    bottom: { style: "thin", color: { rgb: "D6E1DC" } },
+    left: { style: "thin", color: { rgb: "D6E1DC" } },
+    right: { style: "thin", color: { rgb: "D6E1DC" } },
+  },
+};
+
+const roleFill: Record<WellRole, string> = {
+  control: "DCEAE5",
+  sample: "EAF2EE",
+  blank: "F2ECE9",
+  qc: "F1D8C0",
+  standard: "E8E1EF",
+  unassigned: "F3F2EE",
+};
+
+function safeStem(source: string): string {
+  const stem = source.replace(/\.[^.]+$/, "").replace(/[^a-zA-Z0-9\u4e00-\u9fff_-]+/g, "-").replace(/^-+|-+$/g, "");
+  return stem || "microplate";
+}
+
+function applyTableStyle(sheet: XLSX.WorkSheet, widths: number[]): void {
+  const range = XLSX.utils.decode_range(sheet["!ref"] ?? "A1:A1");
+  for (let column = range.s.c; column <= range.e.c; column += 1) {
+    const cell = sheet[XLSX.utils.encode_cell({ r: 0, c: column })];
+    if (cell) cell.s = headerStyle;
+  }
+  sheet["!cols"] = widths.map((wch) => ({ wch }));
+  sheet["!autofilter"] = { ref: XLSX.utils.encode_range({ r: 0, c: 0 }, { r: range.e.r, c: range.e.c }) };
+  sheet["!freeze"] = { xSplit: 0, ySplit: 1, topLeftCell: "A2", activePane: "bottomLeft", state: "frozen" };
+}
+
+function roleLabel(role: WellRole): string {
+  return ({ control: "对照", sample: "样本", blank: "空白", qc: "质控", standard: "标准品", unassigned: "未指定" })[role];
+}
+
+function layoutSheet(plate: ParsedPlate, result: CellViabilityAnalysisResult): XLSX.WorkSheet {
+  const included = new Map(result.annotatedWells.map((well) => [well.well, well]));
+  const rows: unknown[][] = [
+    ["板布局", ...Array.from({ length: plate.columns }, (_, index) => index + 1)],
+  ];
+  for (let rowIndex = 0; rowIndex < plate.rows; rowIndex += 1) {
+    const rowLabel = String.fromCharCode(65 + rowIndex);
+    rows.push([rowLabel, ...Array.from({ length: plate.columns }, (_, columnIndex) => {
+      const well = included.get(`${rowLabel}${columnIndex + 1}`);
+      if (!well) return "";
+      const identity = well.sampleId || well.group || well.instrumentLabel || "未标注";
+      const replicate = [well.biologicalReplicate, well.technicalReplicate].filter(Boolean).join(" · ");
+      return [well.well, `${roleLabel(well.role)} · ${identity}`, replicate, `raw ${well.rawValue}`, well.blankCorrectedValue === null ? "" : `corrected ${well.blankCorrectedValue}`].filter(Boolean).join("\n");
+    })]);
+  }
+  const sheet = XLSX.utils.aoa_to_sheet(rows);
+  sheet["!cols"] = [{ wch: 8 }, ...Array.from({ length: plate.columns }, () => ({ wch: 19 }))];
+  sheet["!rows"] = [{ hpt: 24 }, ...Array.from({ length: plate.rows }, () => ({ hpt: 72 }))];
+  for (let column = 0; column <= plate.columns; column += 1) {
+    const cell = sheet[XLSX.utils.encode_cell({ r: 0, c: column })];
+    if (cell) cell.s = headerStyle;
+  }
+  for (let rowIndex = 1; rowIndex <= plate.rows; rowIndex += 1) {
+    const rowHeader = sheet[XLSX.utils.encode_cell({ r: rowIndex, c: 0 })];
+    if (rowHeader) rowHeader.s = headerStyle;
+    for (let column = 1; column <= plate.columns; column += 1) {
+      const address = `${String.fromCharCode(64 + rowIndex)}${column}`;
+      const well = included.get(address);
+      const cell = sheet[XLSX.utils.encode_cell({ r: rowIndex, c: column })];
+      if (!cell || !well) continue;
+      cell.s = {
+        alignment: { vertical: "top", horizontal: "left", wrapText: true },
+        fill: { fgColor: { rgb: well.excluded ? "E6E2E0" : roleFill[well.role] } },
+        font: { color: { rgb: well.excluded ? "8A817C" : "23302D" }, strike: well.excluded },
+        border: {
+          top: { style: "thin", color: { rgb: "C9D5D0" } },
+          bottom: { style: "thin", color: { rgb: "C9D5D0" } },
+          left: { style: "thin", color: { rgb: "C9D5D0" } },
+          right: { style: "thin", color: { rgb: "C9D5D0" } },
+        },
+      };
+    }
+  }
+  sheet["!freeze"] = { xSplit: 1, ySplit: 1, topLeftCell: "B2", activePane: "bottomRight", state: "frozen" };
+  return sheet;
+}
+
+function exportInfoSheet(plate: ParsedPlate, result: CellViabilityAnalysisResult, scope: string): XLSX.WorkSheet {
+  const rows = [
+    ["字段", "内容"],
+    ["工具", `Microplate Assay Studio v${packageMetadata.version}`],
+    ["导出范围", scope === "all" ? "当前板全部汇总行" : "当前点选的汇总行"],
+    ["板名称", plate.metadata.plateName],
+    ["板 ID", plate.plateId ?? ""],
+    ["来源文件", plate.metadata.sourceFileName],
+    ["导入适配器", plate.metadata.adapterId],
+    ["检测模式", plate.metadata.detectionMode],
+    ["信号单位", plate.metadata.signalUnit],
+    ["Blank mean", result.blankMean ?? ""],
+    ["Blank SD", result.blankSd ?? ""],
+    ["说明", "原始读数保持不变；blank-corrected 值为派生结果。技术复孔先在同一 biological replicate 内汇总，但不作为独立工作表导出。"],
+  ];
+  const sheet = XLSX.utils.aoa_to_sheet(rows);
+  applyTableStyle(sheet, [22, 88]);
+  return sheet;
+}
+
+export function createResultWorkbook(input: {
+  plate: ParsedPlate;
+  result: CellViabilityAnalysisResult;
+  analysisConfig?: AnalysisConfig;
+  scope: string;
+}): ResultWorkbook {
+  const { plate, result, analysisConfig, scope } = input;
+  const workbook = XLSX.utils.book_new();
+  const summarySheet = XLSX.utils.json_to_sheet(biologicalSummaryExportRows(result, plate, analysisConfig));
+  const wellSheet = XLSX.utils.json_to_sheet(annotatedWellExportRows(result, plate));
+  applyTableStyle(summarySheet, [24, 18, 18, 14, 12, 12, 18, 20, 20, 20, 20, 22, 22, 24, 25, 54, 18, 18, 14, 18, 20, 32, 18, 28]);
+  applyTableStyle(wellSheet, [10, 8, 9, 20, 12, 22, 18, 18, 14, 12, 18, 18, 16, 22, 12, 28, 20, 18, 30, 18, 28, 18, 14]);
+  XLSX.utils.book_append_sheet(workbook, exportInfoSheet(plate, result, scope), "导出说明");
+  XLSX.utils.book_append_sheet(workbook, summarySheet, "生物学汇总");
+  XLSX.utils.book_append_sheet(workbook, wellSheet, "孔级数据");
+  XLSX.utils.book_append_sheet(workbook, layoutSheet(plate, result), "板布局");
+  const output = new Uint8Array(XLSX.write(workbook, { type: "array", bookType: "xlsx", compression: true }));
+  return {
+    filename: `${safeStem(plate.metadata.sourceFileName)}-results-${scope}.xlsx`,
+    mimeType: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    bytes: output.buffer.slice(output.byteOffset, output.byteOffset + output.byteLength) as ArrayBuffer,
+  };
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -394,8 +394,8 @@ main { padding-bottom: 40px; }
 .summary-panel-head { display: grid; grid-template-columns: minmax(0,1fr) auto; align-items: start; }
 .summary-panel-head > div:first-child { min-width: 0; }
 .summary-head-actions { display: flex; flex-wrap: wrap; align-items: center; justify-content: flex-end; gap: var(--ln-space-2); max-width: 520px; }
-.summary-head-actions .secondary-button { white-space: nowrap; }
-.secondary-button.mini { min-height: var(--ln-control-height-xs); padding: var(--ln-space-2) 9px; border-radius: var(--ln-radius-sm); font-size: var(--ln-font-size-sm); }
+.summary-head-actions .primary-button,.summary-head-actions .secondary-button { white-space: nowrap; }
+.primary-button.mini,.secondary-button.mini { min-height: var(--ln-control-height-xs); padding: var(--ln-space-2) 9px; border-radius: var(--ln-radius-sm); font-size: var(--ln-font-size-sm); }
 .summary-table-scroll table { min-width: 760px; }
 .summary-table-scroll th:first-child,.summary-table-scroll td:first-child { width: 52px; text-align: center; }
 .summary-table-scroll th:nth-child(2) { min-width: 116px; }
@@ -525,6 +525,7 @@ main { padding-bottom: 40px; }
 .side-section-title span,
 .plate-legend,
 .analysis-summary-strip span,
+.primary-button.mini,
 .secondary-button.mini {
   font-size: var(--ln-font-size-lg);
 }

--- a/tests/result-workbook.test.ts
+++ b/tests/result-workbook.test.ts
@@ -1,0 +1,60 @@
+import XLSX from "xlsx-js-style";
+import { describe, expect, it } from "vitest";
+import { analyzeCellViability } from "../src/core/assays/cck8";
+import { createResultWorkbook } from "../src/core/result-workbook";
+import { fixturePlate } from "./fixtures/plate-fixtures";
+
+const config = {
+  controlGroup: "Control",
+  relativeToControlEnabled: true,
+  technicalCvThresholdPercent: 15,
+  blankCvThresholdPercent: 10,
+};
+
+describe("result workbook export", () => {
+  it("combines the biological summary, well-level data, and plate layout without a technical-summary sheet", () => {
+    const plate = { ...fixturePlate(), plateId: "plate-1" };
+    const result = analyzeCellViability(plate.wells, config);
+    const artifact = createResultWorkbook({ plate, result, analysisConfig: config, scope: "all" });
+    const workbook = XLSX.read(artifact.bytes, { type: "array" });
+
+    expect(artifact.filename).toBe("fixture-results-all.xlsx");
+    expect(workbook.SheetNames).toEqual(["导出说明", "生物学汇总", "孔级数据", "板布局"]);
+    expect(workbook.SheetNames).not.toContain("技术复孔");
+
+    const summaries = XLSX.utils.sheet_to_json<Record<string, unknown>>(workbook.Sheets["生物学汇总"]);
+    const wells = XLSX.utils.sheet_to_json<Record<string, unknown>>(workbook.Sheets["孔级数据"]);
+    const layout = XLSX.utils.sheet_to_json<unknown[]>(workbook.Sheets["板布局"], { header: 1, defval: "" });
+
+    expect(summaries).toHaveLength(2);
+    expect(summaries[0]).toMatchObject({ signal_basis: "blank-corrected", plate_id: "plate-1", source_file: "fixture.tsv" });
+    expect(wells).toHaveLength(6);
+    expect(wells[0]).toMatchObject({ raw_signal: 0.1, plate_id: "plate-1", source_file: "fixture.tsv" });
+    expect(String(layout[2][1])).toContain("B1");
+    expect(String(layout[2][1])).toContain("对照");
+    expect(String(layout[3][1])).toContain("C1");
+    expect(String(layout[3][1])).toContain("样本");
+  });
+
+  it("uses the displayed result as the export scope", () => {
+    const plate = { ...fixturePlate(), plateId: "plate-1" };
+    const full = analyzeCellViability(plate.wells, config);
+    const selected = {
+      ...full,
+      biologicalSummaries: full.biologicalSummaries.filter((row) => row.group === "Drug"),
+      technicalSummaries: full.technicalSummaries.filter((row) => row.group === "Drug"),
+      annotatedWells: full.annotatedWells.filter((well) => well.group === "Drug"),
+      significanceComparisons: full.significanceComparisons.filter((row) => row.group === "Drug"),
+    };
+    const artifact = createResultWorkbook({ plate, result: selected, analysisConfig: config, scope: "selected" });
+    const workbook = XLSX.read(artifact.bytes, { type: "array" });
+    const summaries = XLSX.utils.sheet_to_json<Record<string, unknown>>(workbook.Sheets["生物学汇总"]);
+    const wells = XLSX.utils.sheet_to_json<Record<string, unknown>>(workbook.Sheets["孔级数据"]);
+    const layout = XLSX.utils.sheet_to_json<unknown[]>(workbook.Sheets["板布局"], { header: 1, defval: "" });
+
+    expect(summaries.map((row) => row.group)).toEqual(["Drug"]);
+    expect(wells.map((row) => row.group)).toEqual(["Drug", "Drug"]);
+    expect(layout[2][1]).toBe("");
+    expect(String(layout[3][1])).toContain("C1");
+  });
+});


### PR DESCRIPTION
Closes #41

## Summary
- add one result Excel workbook with export notes, biological summary, well-level data, and a readable plate-layout matrix
- remove the standalone technical-replicate CSV action while retaining technical-replicate aggregation for calculations
- preserve the well-level and biological-summary CSVs for R/Python interoperability
- carry selected summary-row scope and explicit source provenance into workbook exports

## Verification
- `npm test` (53 passed, 6 skipped)
- `npm run build:sites`
- real-browser download and XLSX read-back with exact sheet assertions
- real Varioskan CCK-8 and Dual-Luciferase browser scenarios

## Scientific boundary
Technical replicates remain an internal aggregation layer. The workbook does not promote technical wells to independent biological observations.